### PR TITLE
Always use coordinator endpoint as source

### DIFF
--- a/zigpy_deconz/zigbee/application.py
+++ b/zigpy_deconz/zigbee/application.py
@@ -89,7 +89,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
             dst_ep,
             profile,
             cluster,
-            src_ep,
+            min(1, src_ep),
             data
         )
 


### PR DESCRIPTION
By default zigpy uses `src_ep = dst_ep` for every request, whereas deconz expects `src_ep` to match one of the configured coordinator endpoints. This PR always uses endpoint 1 as `src_ep` which should match the default deconz coordinator endpoint configuration.