### PR TITLE
Add support for version command

### DIFF
--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -117,11 +117,17 @@ async def test_form_network(app):
 
 
 @pytest.mark.asyncio
-async def test_startup(app):
+async def test_startup(app, version=0):
+
+    async def _version():
+        return [version]
+
     app.form_network = mock.MagicMock(
         side_effect=asyncio.coroutine(mock.MagicMock()))
     app._api._command = mock.MagicMock(
         side_effect=asyncio.coroutine(mock.MagicMock()))
+    app._api.version = mock.MagicMock(
+        side_effect=_version)
 
     await app.startup(auto_form=False)
     assert app.form_network.call_count == 0

--- a/zigpy_deconz/api.py
+++ b/zigpy_deconz/api.py
@@ -16,6 +16,7 @@ TX_COMMANDS = {
     'change_network_state': (0x08, (t.uint8_t, ), True),
     'read_parameter': (0x0A, (t.uint16_t, t.uint8_t), True),
     'write_parameter': (0x0B, (t.uint16_t, t.uint8_t, t.Bytes), True),
+    'version': (0x0D, (), True),
     'aps_data_indication': (0x17, (t.uint16_t, t.uint8_t), True),
     'aps_data_request': (
         0x12,
@@ -31,6 +32,7 @@ RX_COMMANDS = {
     'change_network_state': (0x08, (t.uint8_t, ), True),
     'read_parameter': (0x0A, (t.uint16_t, t.uint8_t, t.Bytes), True),
     'write_parameter': (0x0B, (t.uint16_t, t.uint8_t), True),
+    'version': (0x0D, (t.uint32_t, ), True),
     'device_state_changed': (0x0E, (t.uint8_t, t.uint8_t), False),
     'aps_data_indication': (
         0x17,
@@ -212,6 +214,19 @@ class Deconz:
 
     def _handle_write_parameter(self, data):
         LOGGER.debug("Write parameter %s: SUCCESS", NETWORK_PARAMETER_BY_ID[data[1]][0])
+
+    async def version(self):
+        try:
+            return await asyncio.wait_for(
+                self._command('version'),
+                timeout=COMMAND_TIMEOUT
+            )
+        except asyncio.TimeoutError:
+            LOGGER.warning("No response to version command")
+            raise
+
+    def _handle_version(self, data):
+        LOGGER.debug("Version response: %x", data[0])
 
     def _handle_device_state_changed(self, data):
         LOGGER.debug("Device state changed response: %s", data)


### PR DESCRIPTION
Add support for `version` command and only set `watchdog_ttl` if supported.