### PR TITLE
Add link to the new ConBee II (ConBee 2) to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,6 @@
 [zigpy-deconz](https://github.com/zigpy/zigpy-deconz) is a Python 3 implementation for the [Zigpy](https://github.com/zigpy/) project to implement [deCONZ](https://www.dresden-elektronik.de/funktechnik/products/software/pc/deconz/) based [Zigbee](https://www.zigbee.org) radio devices.
 
 
-This uses the deCONZ serial protocol for communicating with [ConBee](https://www.dresden-elektronik.de/conbee/) and [RaspBee](https://www.dresden-elektronik.de/raspbee/) adapters from [Dresden-Elektronik](https://github.com/dresden-elektronik/).
+This uses the deCONZ serial protocol for communicating with [ConBee](https://www.dresden-elektronik.de/conbee/), [ConBee II (ConBee 2)](https://shop.dresden-elektronik.de/conbee-2.html),and [RaspBee](https://www.dresden-elektronik.de/raspbee/) adapters from [Dresden-Elektronik](https://github.com/dresden-elektronik/).
 
 Note! Documentation of the deCONZ serial protocol can currently be obtained by contacting Dresden-Elektronik employees via GitHub here https://github.com/dresden-elektronik/deconz-rest-plugin/issues/158

--- a/README.md
+++ b/README.md
@@ -6,6 +6,6 @@
 [zigpy-deconz](https://github.com/zigpy/zigpy-deconz) is a Python 3 implementation for the [Zigpy](https://github.com/zigpy/) project to implement [deCONZ](https://www.dresden-elektronik.de/funktechnik/products/software/pc/deconz/) based [Zigbee](https://www.zigbee.org) radio devices.
 
 
-This uses the deCONZ serial protocol for communicating with [ConBee](https://www.dresden-elektronik.de/conbee/), [ConBee II (ConBee 2)](https://shop.dresden-elektronik.de/conbee-2.html),and [RaspBee](https://www.dresden-elektronik.de/raspbee/) adapters from [Dresden-Elektronik](https://github.com/dresden-elektronik/).
+This uses the deCONZ serial protocol for communicating with [ConBee](https://www.dresden-elektronik.de/conbee/), [ConBee II (ConBee 2)](https://shop.dresden-elektronik.de/conbee-2.html), and [RaspBee](https://www.dresden-elektronik.de/raspbee/) adapters from [Dresden-Elektronik](https://github.com/dresden-elektronik/).
 
 Note! Documentation of the deCONZ serial protocol can currently be obtained by contacting Dresden-Elektronik employees via GitHub here https://github.com/dresden-elektronik/deconz-rest-plugin/issues/158


### PR DESCRIPTION
FYI; "ConBee II" (a.k.a. "ConBee 2") hardware has been released now and is confirmed to be backwards compatible with the deCONZ serial protocol that zigpy-deconz utilizes. 

Backward compatibility confirmed by Dresden-Elektronik employee @manup to be backwards compatible with the deCONZ serial protocol that zigpy-deconz radio module for zigpy utilizes. (He, @manup wrote that "the serial protocol is identical and will be maintained for all devices equally").

Apparently the new "ConBee II" ZigBee USB dongle/stick features is based on a 32-bit ARM-Cortex-M0 SoC microcontroller (Microchip ATSAMR21E18A) instead of an 8-bit AVR based CMOS microcontroller (Atmel ATmega256RFR2) like the previous version of ConBee and the current RaspBee versions.

- https://shop.dresden-elektronik.de/conbee-2.html
- https://www.dresden-elektronik.de/fileadmin/Downloads/Dokumente/Produkte/11_Phoscon_gateway/Phoscon_ConBee-II_10-2018_eng.pdf
- http://www.amazon.de/dp/B01FDWOIHK