### PR TITLE
Add "simplified_beacon" frame support.

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -107,3 +107,9 @@ def test_data_received(api, monkeypatch):
         assert my_handler.call_args[0][0] == mock.sentinel.deserialize_data
         t.deserialize.reset_mock()
         my_handler.reset_mock()
+
+
+def test_simplified_beacon(api):
+    api._handle_simplified_beacon(
+        (0x0007, 0x1234, 0x5678, 0x19, 0x00, 0x01)
+    )

--- a/zigpy_deconz/api.py
+++ b/zigpy_deconz/api.py
@@ -51,6 +51,8 @@ RX_COMMANDS = {
     ),
     'mac_poll': (0x1C, (t.uint16_t, t.DeconzAddress, t.uint8_t, t.int8s), False),
     'zigbee_green_power': (0x19, (t.LVBytes, ), False),
+    'simplified_beacon': (0x1f, (t.uint16_t, t.uint16_t, t.uint16_t, t.uint8_t,
+                          t.uint8_t, t.uint8_t), False)
 }
 
 NETWORK_PARAMETER = {
@@ -282,6 +284,12 @@ class Deconz:
 
     def _handle_zigbee_green_power(self, data):
         pass
+
+    def _handle_simplified_beacon(self, data):
+        LOGGER.debug(("Received simplified beacon frame: source=0x%04x, "
+                      "pan_id=0x%04x, channel=%s, flags=0x%02x, "
+                      "update_id=0x%02x"),
+                     data[1], data[2], data[3], data[4], data[5])
 
     def _handle_device_state_value(self, value):
         flags = [i for i in DEVICE_STATE if (value & i.value) == i.value]


### PR DESCRIPTION
`Frame received: 0x1f27000e0007000a89d212190000`
```
case ZM_CMD_BEACON:
    {
        const uint BEACON_LEN = 7;

        deCONZ::Beacon b;

        const uint8_t *p = cmd->buffer.data;
        quint16 len = cmd->buffer.len;

        while (len >= BEACON_LEN)
        {
            p = get_u16_le(p, &b.source);
            p = get_u16_le(p, &b.panId);
            p = get_u8_le(p, &b.channel);
            p = get_u8_le(p, &b.flags);
            p = get_u8_le(p, &b.updateId);

            emit beacon(b);

            len -= BEACON_LEN;

        }
    }
```

https://github.com/dresden-elektronik/deconz-rest-plugin/issues/158#issuecomment-502687797
