### PR TITLE
Implement source address mode 0x04.

### DIFF
--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,5 +1,3 @@
-import pytest
-
 import zigpy_deconz.types as t
 
 
@@ -15,9 +13,6 @@ def test_deconz_address_group():
 
     assert addr.serialize() == data
 
-    with pytest.raises(ValueError):
-        t.DeconzAddress.deserialize(data[:-1])
-
 
 def test_deconz_address_nwk():
     data = b'\x02\x55\xaa'
@@ -30,9 +25,6 @@ def test_deconz_address_nwk():
     assert addr.address == 0xaa55
 
     assert addr.serialize() == data
-
-    with pytest.raises(ValueError):
-        t.DeconzAddress.deserialize(data[:-1])
 
 
 def test_deconz_address_ieee():
@@ -47,9 +39,6 @@ def test_deconz_address_ieee():
 
     assert addr.serialize() == data
 
-    with pytest.raises(ValueError):
-        t.DeconzAddress.deserialize(data[:-1])
-
 
 def test_deconz_address_nwk_and_ieee():
     data = b'\x04\x55\xaa\x88\x99\xbb\xcc\xdd\xee\xef\xbe'
@@ -63,6 +52,3 @@ def test_deconz_address_nwk_and_ieee():
     assert addr.address == 0xaa55
 
     assert addr.serialize() == data
-
-    with pytest.raises(ValueError):
-        t.DeconzAddress.deserialize(data[:-1])

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,0 +1,68 @@
+import pytest
+
+import zigpy_deconz.types as t
+
+
+def test_deconz_address_group():
+    data = b'\x01\x55\xaa'
+    extra = b'the rest of the owl'
+
+    addr, rest = t.DeconzAddress.deserialize(data + extra)
+    assert rest == extra
+    assert addr.address_mode == t.ADDRESS_MODE.GROUP
+    assert addr.address_mode == 1
+    assert addr.address == 0xaa55
+
+    assert addr.serialize() == data
+
+    with pytest.raises(ValueError):
+        t.DeconzAddress.deserialize(data[:-1])
+
+
+def test_deconz_address_nwk():
+    data = b'\x02\x55\xaa'
+    extra = b'the rest of the owl'
+
+    addr, rest = t.DeconzAddress.deserialize(data + extra)
+    assert rest == extra
+    assert addr.address_mode == t.ADDRESS_MODE.NWK
+    assert addr.address_mode == 2
+    assert addr.address == 0xaa55
+
+    assert addr.serialize() == data
+
+    with pytest.raises(ValueError):
+        t.DeconzAddress.deserialize(data[:-1])
+
+
+def test_deconz_address_ieee():
+    data = b'\x03\x55\xaa\xbb\xcc\xdd\xee\xef\xbe'
+    extra = b'the rest of the owl'
+
+    addr, rest = t.DeconzAddress.deserialize(data + extra)
+    assert rest == extra
+    assert addr.address_mode == t.ADDRESS_MODE.IEEE
+    assert addr.address_mode == 3
+    assert addr.address == [0xbe, 0xef, 0xee, 0xdd, 0xcc, 0xbb, 0xaa, 0x55]
+
+    assert addr.serialize() == data
+
+    with pytest.raises(ValueError):
+        t.DeconzAddress.deserialize(data[:-1])
+
+
+def test_deconz_address_nwk_and_ieee():
+    data = b'\x04\x55\xaa\x88\x99\xbb\xcc\xdd\xee\xef\xbe'
+    extra = b'the rest of the owl'
+
+    addr, rest = t.DeconzAddress.deserialize(data + extra)
+    assert rest == extra
+    assert addr.address_mode == t.ADDRESS_MODE.NWK_AND_IEEE
+    assert addr.address_mode == 4
+    assert addr.ieee == [0xbe, 0xef, 0xee, 0xdd, 0xcc, 0xbb, 0x99, 0x88]
+    assert addr.address == 0xaa55
+
+    assert addr.serialize() == data
+
+    with pytest.raises(ValueError):
+        t.DeconzAddress.deserialize(data[:-1])


### PR DESCRIPTION
deCONZ serial protocol versions 0x010b and newer support source address mode `0x04` which includes both short network address and IEEE address. This PR implements address mode 0x04 for `DeconzAddress` class.
![image](https://user-images.githubusercontent.com/5826160/59648224-528c9e00-914c-11e9-848c-b0850174b89f.png)
