### PR TITLE
Bail out on data_received deserialization failure.

### DIFF
--- a/zigpy_deconz/api.py
+++ b/zigpy_deconz/api.py
@@ -157,8 +157,12 @@ class Deconz:
             status = data[2]
         try:
             data, _ = t.deserialize(data[5:], RX_COMMANDS[command][1])
-        except Exception:
+        except Exception as exc:
             LOGGER.warning("Failed to deserialize frame: %s", binascii.hexlify(data))
+            if RX_COMMANDS[command][2]:
+                fut, = self._awaiting.pop(seq)
+                fut.set_exception(exc)
+            return
         if RX_COMMANDS[command][2]:
             fut, = self._awaiting.pop(seq)
             if status != STATUS.SUCCESS:


### PR DESCRIPTION
Don't follow through data_received() handling, if command deserialization throws an exception.

If we get an Exception trying to deserialize incoming frame command payload, then it doesn't make sense just suppressing the exception. Instead we should bail out immediately. 