### PR TITLE
Refactor Deconz._command() method.

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7,9 +7,6 @@ from zigpy_deconz import api as deconz_api, types as t, uart
 import zigpy_deconz.exception
 
 
-COMMANDS = [*deconz_api.TX_COMMANDS.items(), *deconz_api.RX_COMMANDS.items()]
-
-
 @pytest.fixture
 def api():
     api = deconz_api.Deconz()
@@ -41,7 +38,7 @@ def test_close(api):
 def test_commands():
     import string
     anum = string.ascii_letters + string.digits + '_'
-    for cmd_name, cmd_opts in COMMANDS:
+    for cmd_name, cmd_opts in deconz_api.RX_COMMANDS.items():
         assert isinstance(cmd_name, str) is True
         assert all([c in anum for c in cmd_name]), cmd_name
         assert len(cmd_opts) == 3
@@ -50,12 +47,19 @@ def test_commands():
         assert isinstance(schema, tuple) is True
         assert reply is None or isinstance(reply, bool)
 
+    for cmd_name, cmd_opts in deconz_api.TX_COMMANDS.items():
+        assert isinstance(cmd_name, str) is True
+        assert all([c in anum for c in cmd_name]), cmd_name
+        assert len(cmd_opts) == 2
+        cmd_id, schema = cmd_opts
+        assert isinstance(cmd_id, int) is True
+        assert isinstance(schema, tuple) is True
+
 
 @pytest.mark.asyncio
 async def test_command(api, monkeypatch):
     def mock_api_frame(name, *args):
-        c = deconz_api.TX_COMMANDS[name]
-        return mock.sentinel.api_frame_data, c[2]
+        return mock.sentinel.api_frame_data
     api._api_frame = mock.MagicMock(side_effect=mock_api_frame)
     api._uart.send = mock.MagicMock()
 
@@ -64,12 +68,29 @@ async def test_command(api, monkeypatch):
     monkeypatch.setattr(asyncio, 'Future', mock_fut)
 
     for cmd_name, cmd_opts in deconz_api.TX_COMMANDS.items():
-        _, _, expect_reply = cmd_opts
         ret = await api._command(cmd_name, mock.sentinel.cmd_data)
-        if expect_reply:
-            assert ret is mock.sentinel.cmd_result
-        else:
-            assert ret is None
+        assert ret is mock.sentinel.cmd_result
+        assert api._api_frame.call_count == 1
+        assert api._api_frame.call_args[0][0] == cmd_name
+        assert api._api_frame.call_args[0][1] == mock.sentinel.cmd_data
+        assert api._uart.send.call_count == 1
+        assert api._uart.send.call_args[0][0] == mock.sentinel.api_frame_data
+        api._api_frame.reset_mock()
+        api._uart.send.reset_mock()
+
+
+@pytest.mark.asyncio
+async def test_command_timeout(api, monkeypatch):
+    def mock_api_frame(name, *args):
+        return mock.sentinel.api_frame_data
+    api._api_frame = mock.MagicMock(side_effect=mock_api_frame)
+    api._uart.send = mock.MagicMock()
+
+    monkeypatch.setattr(deconz_api, 'COMMAND_TIMEOUT', 0.1)
+
+    for cmd_name, cmd_opts in deconz_api.TX_COMMANDS.items():
+        with pytest.raises(asyncio.TimeoutError):
+            await api._command(cmd_name, mock.sentinel.cmd_data)
         assert api._api_frame.call_count == 1
         assert api._api_frame.call_args[0][0] == cmd_name
         assert api._api_frame.call_args[0][1] == mock.sentinel.cmd_data
@@ -85,7 +106,7 @@ def test_api_frame(api):
     addr.address = t.uint8_t(0)
     addr.endpoint = t.uint8_t(0)
     for cmd_name, cmd_opts in deconz_api.TX_COMMANDS.items():
-        _, schema, _ = cmd_opts
+        _, schema = cmd_opts
         if schema:
             args = [addr if isinstance(a(), t.DeconzAddressEndpoint) else a() for a in schema]
             api._api_frame(cmd_name, *args)
@@ -103,7 +124,7 @@ def test_data_received(api, monkeypatch):
         payload = b'\x01\x02\x03\x04'
         data = cmd_id.to_bytes(1, 'big') + b'\x00\x00\x00\x00' + payload
         setattr(api, '_handle_{}'.format(cmd), my_handler)
-        api._awaiting[0] = (mock.MagicMock(), )
+        api._awaiting[0] = mock.MagicMock()
         api.data_received(data)
         assert t.deserialize.call_count == 1
         assert t.deserialize.call_args[0][0] == payload
@@ -125,7 +146,7 @@ def test_data_received_unk_status(api, monkeypatch):
         data = cmd_id.to_bytes(1, 'big') + b'\x00' + \
             status + b'\x00\x00' + payload
         setattr(api, '_handle_{}'.format(cmd), my_handler)
-        api._awaiting[0] = (mock.MagicMock(), )
+        api._awaiting[0] = mock.MagicMock()
         api.data_received(data)
         assert t.deserialize.call_count == 1
         assert t.deserialize.call_args[0][0] == payload


### PR DESCRIPTION
Deconz serial protocol implies a response frame to every request frame sent to Conbee. So no point assuming there are cases when there's no a reply to a command sent to Conbee. 