### PR TITLE
Enable watchdog based on protocol version.

### DIFF
--- a/zigpy_deconz/api.py
+++ b/zigpy_deconz/api.py
@@ -149,6 +149,11 @@ class Deconz:
         self._proto_ver = None
         self._aps_data_ind_flags = 0x01
 
+    @property
+    def protocol_version(self):
+        """Protocol Version."""
+        return self._proto_ver
+
     def set_application(self, app):
         self._app = app
 
@@ -268,7 +273,8 @@ class Deconz:
     async def version(self):
         self._proto_ver = await self[NetworkParameter.protocol_version]
         version = await self._command(Command.version)
-        if self._proto_ver >= MIN_PROTO_VERSION and (version[0] & 0x0000FF00) == 0x00000500:
+        if self.protocol_version >= MIN_PROTO_VERSION and \
+                (version[0] & 0x0000FF00) == 0x00000500:
             self._aps_data_ind_flags = 0x04
         return version[0]
 

--- a/zigpy_deconz/zigbee/application.py
+++ b/zigpy_deconz/zigbee/application.py
@@ -16,6 +16,7 @@ LOGGER = logging.getLogger(__name__)
 
 CHANGE_NETWORK_WAIT = 1
 SEND_CONFIRM_TIMEOUT = 60
+PROTO_VER_WATCHDOG = 0x0108
 
 
 class ControllerApplication(zigpy.application.ControllerApplication):
@@ -57,7 +58,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         await self._api[NetworkParameter.nwk_update_id]
         self._api[NetworkParameter.aps_designed_coordinator] = 1
 
-        if self.version > 0x261f0500:
+        if self._api.protocol_version >= PROTO_VER_WATCHDOG:
             asyncio.ensure_future(self._reset_watchdog())
 
         if auto_form:


### PR DESCRIPTION
We should be using protocol version instead of the firmware version for feature detection as per protocol specs:
![image](https://user-images.githubusercontent.com/5826160/66507766-d07b0900-ea9d-11e9-8105-8148dd70d80c.png)
