### PR TITLE
Implement radio probe.

### DIFF
--- a/zigpy_deconz/exception.py
+++ b/zigpy_deconz/exception.py
@@ -2,7 +2,7 @@ from zigpy.exceptions import APIException
 
 
 class CommandError(APIException):
-    def __init__(self, status, *args, **kwargs):
+    def __init__(self, status=1, *args, **kwargs):
         self._status = status
         super().__init__(*args, **kwargs)
 


### PR DESCRIPTION
Implement a method allowing upper layer applications to detect whether a correct radio module is present on a given serial port .

Implements `zigpy_deconz.api.Decons.probe(port, baudrate) -> bool` async class method, which return `True` if radio was detected on `port` path or `False` otherwise. All exceptions are consumed by the method. 