### PR TITLE
Add a command queue so there is always only one pending command

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -14,7 +14,7 @@ DEVICE_CONFIG = {zigpy.config.CONF_DEVICE_PATH: "/dev/null"}
 
 
 @pytest.fixture
-def api():
+def api(event_loop):
     controller = mock.MagicMock(
         spec_set=zigpy_deconz.zigbee.application.ControllerApplication
     )
@@ -78,6 +78,26 @@ async def test_command(api, monkeypatch):
         assert api._api_frame.call_args[0][1] == mock.sentinel.cmd_data
         assert api._uart.send.call_count == 1
         assert api._uart.send.call_args[0][0] == mock.sentinel.api_frame_data
+        api._api_frame.reset_mock()
+        api._uart.send.reset_mock()
+
+
+@pytest.mark.asyncio
+async def test_command_queue(api, monkeypatch):
+    def mock_api_frame(name, *args):
+        return mock.sentinel.api_frame_data, api._seq
+
+    api._api_frame = mock.MagicMock(side_effect=mock_api_frame)
+    api._uart.send = mock.MagicMock()
+
+    monkeypatch.setattr(deconz_api, "COMMAND_TIMEOUT", 0.1)
+
+    for cmd, cmd_opts in deconz_api.TX_COMMANDS.items():
+        async with api._command_lock:
+            with pytest.raises(asyncio.TimeoutError):
+                await asyncio.wait_for(api._command(cmd, mock.sentinel.cmd_data), 0.1)
+        assert api._api_frame.call_count == 0
+        assert api._uart.send.call_count == 0
         api._api_frame.reset_mock()
         api._uart.send.reset_mock()
 

--- a/zigpy_deconz/api.py
+++ b/zigpy_deconz/api.py
@@ -204,6 +204,7 @@ class Deconz:
         self._app = app
         self._aps_data_ind_flags: int = 0x01
         self._awaiting = {}
+        self._command_lock = asyncio.Lock()
         self._config = device_config
         self._conn_lost_task: Optional[asyncio.Task] = None
         self._data_indication: bool = False
@@ -275,20 +276,23 @@ class Deconz:
             self._uart = None
 
     async def _command(self, cmd, *args):
-        LOGGER.debug("Command %s %s", cmd, args)
         if self._uart is None:
             # connection was lost
             raise CommandError(Status.ERROR, "API is not running")
-        data, seq = self._api_frame(cmd, *args)
-        self._uart.send(data)
-        fut = asyncio.Future()
-        self._awaiting[seq] = fut
-        try:
-            return await asyncio.wait_for(fut, timeout=COMMAND_TIMEOUT)
-        except asyncio.TimeoutError:
-            LOGGER.warning("No response to '%s' command", cmd)
-            self._awaiting.pop(seq)
-            raise
+        async with self._command_lock:
+            LOGGER.debug("Command %s %s", cmd, args)
+            data, seq = self._api_frame(cmd, *args)
+            self._uart.send(data)
+            fut = asyncio.Future()
+            self._awaiting[seq] = fut
+            try:
+                return await asyncio.wait_for(fut, timeout=COMMAND_TIMEOUT)
+            except asyncio.TimeoutError:
+                LOGGER.warning(
+                    "No response to '%s' command with seq id '0x%02x'", cmd, seq
+                )
+                self._awaiting.pop(seq)
+                raise
 
     def _api_frame(self, cmd, *args):
         schema = TX_COMMANDS[cmd]


### PR DESCRIPTION
On RaspBee II modules (Firmware 26520700) sending multiple concurrent commands may result in missing command responses and duplicate device_state_changed commands. Sending commands one at a time with waiting for their response, seems to fix this issue.

Fixes #107 