### PR TITLE
Restore coordinator directly connected children

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,6 +8,8 @@ max-line-length = 88
 ignore =
     W503,
     E203,
+    D101,
+    D102,
     D103,
     D202
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-"""Setup module for zigpy-deconz"""
+"""Setup module for zigpy-deconz."""
 
 import os
 
@@ -21,6 +21,6 @@ setup(
     author_email="schmidt.d@aon.at",
     license="GPL-3.0",
     packages=find_packages(exclude=["*.tests"]),
-    install_requires=["pyserial-asyncio", "zigpy>=0.20.a1"],
+    install_requires=["pyserial-asyncio", "zigpy>=0.24.0"],
     tests_require=["pytest", "pytest-asyncio", "asynctest"],
 )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -561,3 +561,8 @@ def test_tx_status(value, name):
     assert status == value
     assert status.value == value
     assert status.name == name
+
+
+def test_handle_add_neighbour(api):
+    """Test handle_add_neighbour."""
+    api._handle_add_neighbour((12, 1, 0x1234, sentinel.ieee, 0x80))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -139,17 +139,23 @@ async def test_command_not_connected(api):
         api._api_frame.reset_mock()
 
 
+def _fake_args(arg_type):
+    if isinstance(arg_type(), t.DeconzAddressEndpoint):
+        addr = t.DeconzAddressEndpoint()
+        addr.address_mode = t.ADDRESS_MODE.NWK
+        addr.address = t.uint8_t(0)
+        addr.endpoint = t.uint8_t(0)
+        return addr
+    if isinstance(arg_type(), t.EUI64):
+        return t.EUI64([0x01] * 8)
+
+    return arg_type()
+
+
 def test_api_frame(api):
-    addr = t.DeconzAddressEndpoint()
-    addr.address_mode = t.ADDRESS_MODE.NWK
-    addr.address = t.uint8_t(0)
-    addr.endpoint = t.uint8_t(0)
     for cmd, schema in deconz_api.TX_COMMANDS.items():
         if schema:
-            args = [
-                addr if isinstance(a(), t.DeconzAddressEndpoint) else a()
-                for a in schema
-            ]
+            args = [_fake_args(a) for a in schema]
             api._api_frame(cmd, *args)
         else:
             api._api_frame(cmd)

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -216,6 +216,7 @@ async def test_startup(protocol_ver, watchdog_cc, app, monkeypatch, version=0):
 
     app._reset_watchdog = AsyncMock()
     app.form_network = AsyncMock()
+    app._delayed_neighbour_scan = AsyncMock()
 
     app._api._command = AsyncMock()
     api = deconz_api.Deconz(app, app._config[zigpy.config.CONF_DEVICE])
@@ -225,7 +226,11 @@ async def test_startup(protocol_ver, watchdog_cc, app, monkeypatch, version=0):
     api.version = MagicMock(side_effect=_version)
     api.write_parameter = AsyncMock()
 
-    monkeypatch.setattr(application.DeconzDevice, "new", AsyncMock())
+    monkeypatch.setattr(
+        application.DeconzDevice,
+        "new",
+        AsyncMock(return_value=zigpy.device.Device(app, sentinel.ieee, 0x0000)),
+    )
     with patch.object(application, "Deconz", return_value=api):
         await app.startup(auto_form=False)
         assert app.form_network.call_count == 0

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -614,3 +614,22 @@ async def test_restore_neighbours(app):
 
     assert api_mock.add_neighbour.call_count == 1
     assert api_mock.add_neighbour.await_count == 1
+
+
+@patch("zigpy_deconz.zigbee.application.DELAY_NEIGHBOUR_SCAN_S", 0)
+async def test_delayed_scan():
+    """Delayed scan."""
+
+    coord = MagicMock()
+    coord.neighbors.scan = AsyncMock()
+    config = application.ControllerApplication.SCHEMA(
+        {
+            zigpy.config.CONF_DEVICE: {zigpy.config.CONF_DEVICE_PATH: "usb0"},
+            zigpy.config.CONF_DATABASE: "tmp",
+        }
+    )
+
+    app = application.ControllerApplication(config)
+    with patch.object(app, "get_device", return_value=coord):
+        await app._delayed_neighbour_scan()
+    assert coord.neighbors.scan.await_count == 1

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -36,7 +36,8 @@ def app(device_path, database_file=None):
 
     app = application.ControllerApplication(config)
     api = MagicMock(spec_set=zigpy_deconz.api.Deconz)
-    with patch.object(app, "_api", return_value=api):
+    p2 = patch.object(app, "_delayed_neighbour_scan")
+    with patch.object(app, "_api", return_value=api), p2:
         yield app
 
 

--- a/zigpy_deconz/api.py
+++ b/zigpy_deconz/api.py
@@ -1,3 +1,5 @@
+"""deCONZ serial protocol API."""
+
 import asyncio
 import binascii
 import enum
@@ -200,7 +202,10 @@ NETWORK_PARAMETER_SCHEMA = {
 
 
 class Deconz:
+    """deCONZ API class."""
+
     def __init__(self, app: Callable, device_config: Dict[str, Any]):
+        """Init instance."""
         self._app = app
         self._aps_data_ind_flags: int = 0x01
         self._awaiting = {}
@@ -373,7 +378,7 @@ class Deconz:
         return False
 
     async def _probe(self) -> None:
-        """Open port and try sending a command"""
+        """Open port and try sending a command."""
         await self.connect()
         await self.device_state()
         self.close()
@@ -567,7 +572,9 @@ class Deconz:
             asyncio.ensure_future(self._aps_data_confirm())
 
     def __getitem__(self, key):
+        """Access parameters via getitem."""
         return self.read_parameter(key)
 
     def __setitem__(self, key, value):
+        """Set parameters via setitem."""
         return asyncio.ensure_future(self.write_parameter(key, value))

--- a/zigpy_deconz/zigbee/application.py
+++ b/zigpy_deconz/zigbee/application.py
@@ -309,12 +309,12 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         neigbours = (nei.device for nei in coord.neighbors)
         for nei_device in neigbours:
             LOGGER.debug(
-                "%s device, FFD=%s, Rx_on_when_idle=%s: %s %s",
-                nei_device.ieee,
-                nei_device.node_desc.is_full_function_device,
-                nei_device.node_desc.is_receiver_on_when_idle,
+                "device: 0x%04x - %s %s, FFD=%s, Rx_on_when_idle=%s",
+                nei_device.nwk,
                 nei_device.manufacturer,
                 nei_device.model,
+                nei_device.node_desc.is_full_function_device,
+                nei_device.node_desc.is_receiver_on_when_idle,
             )
             if nei_device is None:
                 continue

--- a/zigpy_deconz/zigbee/application.py
+++ b/zigpy_deconz/zigbee/application.py
@@ -24,6 +24,7 @@ LOGGER = logging.getLogger(__name__)
 CHANGE_NETWORK_WAIT = 1
 SEND_CONFIRM_TIMEOUT = 60
 PROTO_VER_WATCHDOG = 0x0108
+PROTO_VER_NEIGBOURS = 0x0107
 WATCHDOG_TTL = 600
 
 
@@ -91,7 +92,8 @@ class ControllerApplication(zigpy.application.ControllerApplication):
 
         coordinator.neighbors.add_context_listener(self._dblistener)
         self.devices[self.ieee] = coordinator
-        await self.restore_neighbours()
+        if self._api.protocol_version >= PROTO_VER_NEIGBOURS:
+            await self.restore_neighbours()
 
     async def force_remove(self, dev):
         """Forcibly remove device from NCP."""

--- a/zigpy_deconz/zigbee/application.py
+++ b/zigpy_deconz/zigbee/application.py
@@ -77,13 +77,16 @@ class ControllerApplication(zigpy.application.ControllerApplication):
 
         if auto_form:
             await self.form_network()
-        self.devices[self.ieee] = await DeconzDevice.new(
+        coordinator = await DeconzDevice.new(
             self,
             self.ieee,
             self.nwk,
             self.version,
             self._config[zigpy.config.CONF_DEVICE][zigpy.config.CONF_DEVICE_PATH],
         )
+
+        coordinator.neighbors.add_context_listener(self._dblistener)
+        self.devices[self.ieee] = coordinator
 
     async def force_remove(self, dev):
         """Forcibly remove device from NCP."""

--- a/zigpy_deconz/zigbee/application.py
+++ b/zigpy_deconz/zigbee/application.py
@@ -305,31 +305,31 @@ class ControllerApplication(zigpy.application.ControllerApplication):
 
     async def restore_neighbours(self) -> None:
         """Restore children."""
-        coord = self.devices[self.ieee]
-        neigbours = (nei.device for nei in coord.neighbors)
-        for nei_device in neigbours:
+        coord = self.get_device(ieee=self.ieee)
+        devices = (nei.device for nei in coord.neighbors)
+        for device in devices:
+            if device is None:
+                continue
             LOGGER.debug(
                 "device: 0x%04x - %s %s, FFD=%s, Rx_on_when_idle=%s",
-                nei_device.nwk,
-                nei_device.manufacturer,
-                nei_device.model,
-                nei_device.node_desc.is_full_function_device,
-                nei_device.node_desc.is_receiver_on_when_idle,
+                device.nwk,
+                device.manufacturer,
+                device.model,
+                device.node_desc.is_full_function_device,
+                device.node_desc.is_receiver_on_when_idle,
             )
-            if nei_device is None:
-                continue
-            descr = nei_device.node_desc
+            descr = device.node_desc
             if not descr.is_valid:
                 continue
             if descr.is_full_function_device or descr.is_receiver_on_when_idle:
                 continue
             LOGGER.debug(
                 "Restoring %s/0x%04x device as direct child",
-                nei_device.ieee,
-                nei_device.nwk,
+                device.ieee,
+                device.nwk,
             )
             await self._api.add_neighbour(
-                0x01, nei_device.nwk, nei_device.ieee, descr.mac_capability_flags
+                0x01, device.nwk, device.ieee, descr.mac_capability_flags
             )
 
     async def _delayed_neighbour_scan(self) -> None:


### PR DESCRIPTION
Fixes #118 

On power cycle, ConBee/RaspBee looses all directly connected children, which could be a problem if there are no other routers on the network. Restore directly connected children from previously scanned neighbours.
