### PR TITLE
Refactor network formation

### DIFF
--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -18,6 +18,14 @@ import zigpy_deconz.zigbee.application as application
 from .async_mock import AsyncMock, MagicMock, patch, sentinel
 
 pytestmark = pytest.mark.asyncio
+ZIGPY_NWK_CONFIG = {
+    zigpy.config.CONF_NWK: {
+        zigpy.config.CONF_NWK_PAN_ID: 0x4567,
+        zigpy.config.CONF_NWK_EXTENDED_PAN_ID: "11:22:33:44:55:66:77:88",
+        zigpy.config.CONF_NWK_UPDATE_ID: 22,
+        zigpy.config.CONF_NWK_KEY: [0xAA] * 16,
+    }
+}
 
 
 @pytest.fixture
@@ -26,18 +34,30 @@ def device_path():
 
 
 @pytest.fixture
-def app(device_path, database_file=None):
+def api():
+    """Return API fixture."""
+    api = MagicMock(spec_set=zigpy_deconz.api.Deconz)
+    api.device_state = AsyncMock(
+        return_value=(deconz_api.DeviceState(deconz_api.NetworkState.CONNECTED), 0, 0)
+    )
+    api.write_parameter = AsyncMock()
+    api.change_network_state = AsyncMock()
+    return api
+
+
+@pytest.fixture
+def app(device_path, api, database_file=None):
     config = application.ControllerApplication.SCHEMA(
         {
+            **ZIGPY_NWK_CONFIG,
             zigpy.config.CONF_DEVICE: {zigpy.config.CONF_DEVICE_PATH: device_path},
             zigpy.config.CONF_DATABASE: database_file,
         }
     )
 
     app = application.ControllerApplication(config)
-    api = MagicMock(spec_set=zigpy_deconz.api.Deconz)
     p2 = patch.object(app, "_delayed_neighbour_scan")
-    with patch.object(app, "_api", return_value=api), p2:
+    with patch.object(app, "_api", api), p2:
         yield app
 
 
@@ -185,25 +205,34 @@ def test_rx_unknown_device(app, addr_ieee, addr_nwk, caplog):
     assert app.handle_message.call_count == 0
 
 
-async def test_form_network(app):
-    app._api.change_network_state = AsyncMock()
-    app._api.device_state = AsyncMock(return_value=deconz_api.NetworkState.CONNECTED)
-    app._api.network_state = deconz_api.NetworkState.CONNECTED
+@patch.object(application, "CHANGE_NETWORK_WAIT", 0.001)
+async def test_form_network(app, api):
+    """Test network forming."""
 
     await app.form_network()
-    assert app._api.change_network_state.call_count == 0
-    assert app._api.change_network_state.await_count == 0
-    assert app._api.device_state.await_count == 0
+    assert api.change_network_state.await_count == 2
+    assert (
+        api.change_network_state.call_args_list[0][0][0]
+        == deconz_api.NetworkState.OFFLINE
+    )
+    assert (
+        api.change_network_state.call_args_list[1][0][0]
+        == deconz_api.NetworkState.CONNECTED
+    )
+    assert api.write_parameter.await_count >= 3
+    assert (
+        api.write_parameter.await_args_list[0][0][0]
+        == deconz_api.NetworkParameter.aps_designed_coordinator
+    )
+    assert api.write_parameter.await_args_list[0][0][1] == 1
 
-    app._api._device_state = deconz_api.DeviceState(deconz_api.NetworkState.OFFLINE)
-    app._api.network_state = deconz_api.NetworkState.OFFLINE
-    application.CHANGE_NETWORK_WAIT = 0.001
+    api.device_state.return_value = (
+        deconz_api.DeviceState(deconz_api.NetworkState.JOINING),
+        0,
+        0,
+    )
     with pytest.raises(Exception):
         await app.form_network()
-    assert app._api.change_network_state.call_count == 1
-    assert app._api.change_network_state.await_count == 1
-    assert app._api.device_state.await_count == 10
-    assert app._api.device_state.call_count == 10
 
 
 @pytest.mark.parametrize(

--- a/zigpy_deconz/api.py
+++ b/zigpy_deconz/api.py
@@ -351,16 +351,14 @@ class Deconz:
         getattr(self, "_handle_%s" % (command.name,))(data)
 
     add_neighbour = functools.partialmethod(_command, Command.add_neighbour, 12)
-
-    def device_state(self):
-        return self._command(Command.device_state, 0, 0, 0)
+    device_state = functools.partialmethod(_command, Command.device_state, 0, 0, 0)
+    change_network_state = functools.partialmethod(
+        _command, Command.change_network_state
+    )
 
     def _handle_device_state(self, data):
         LOGGER.debug("Device state response: %s", data)
         self._handle_device_state_value(data[0])
-
-    def change_network_state(self, state):
-        return self._command(Command.change_network_state, state)
 
     def _handle_change_network_state(self, data):
         LOGGER.debug("Change network state response: %s", NetworkState(data[0]).name)

--- a/zigpy_deconz/api.py
+++ b/zigpy_deconz/api.py
@@ -17,7 +17,7 @@ import zigpy_deconz.uart
 
 LOGGER = logging.getLogger(__name__)
 
-COMMAND_TIMEOUT = 1
+COMMAND_TIMEOUT = 1.8
 PROBE_TIMEOUT = 2
 MIN_PROTO_VERSION = 0x010B
 

--- a/zigpy_deconz/api.py
+++ b/zigpy_deconz/api.py
@@ -9,7 +9,7 @@ from typing import Any, Callable, Dict, Optional, Tuple
 
 import serial
 from zigpy.config import CONF_DEVICE_PATH
-from zigpy.types import APSStatus
+from zigpy.types import APSStatus, Channels
 
 from zigpy_deconz.exception import APIException, CommandError
 import zigpy_deconz.types as t
@@ -192,7 +192,7 @@ NETWORK_PARAMETER_SCHEMA = {
     NetworkParameter.nwk_address: (t.NWK,),
     NetworkParameter.nwk_extended_panid: (t.ExtendedPanId,),
     NetworkParameter.aps_designed_coordinator: (t.uint8_t,),
-    NetworkParameter.channel_mask: (t.uint32_t,),
+    NetworkParameter.channel_mask: (Channels,),
     NetworkParameter.aps_extended_panid: (t.ExtendedPanId,),
     NetworkParameter.trust_center_address: (t.EUI64,),
     NetworkParameter.security_mode: (t.uint8_t,),

--- a/zigpy_deconz/zigbee/application.py
+++ b/zigpy_deconz/zigbee/application.py
@@ -143,10 +143,6 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         for _ in range(10):
             (state, _, _) = await self._api.device_state()
             if state.network_state == NetworkState.CONNECTED:
-                channel_mask = nwk_config[zigpy.config.CONF_NWK_CHANNELS]
-                await self._api.write_parameter(
-                    NetworkParameter.channel_mask, channel_mask
-                )
                 return
             await asyncio.sleep(CHANGE_NETWORK_WAIT)
         raise Exception("Could not form network.")

--- a/zigpy_deconz/zigbee/application.py
+++ b/zigpy_deconz/zigbee/application.py
@@ -108,7 +108,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         """Forcibly remove device from NCP."""
         pass
 
-    async def form_network(self, channel=15, pan_id=None, extended_pan_id=None):
+    async def form_network(self):
         LOGGER.info("Forming network")
         await self._api.change_network_state(NetworkState.OFFLINE)
         await self._api.write_parameter(NetworkParameter.aps_designed_coordinator, 1)

--- a/zigpy_deconz/zigbee/application.py
+++ b/zigpy_deconz/zigbee/application.py
@@ -143,6 +143,10 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         for _ in range(10):
             (state, _, _) = await self._api.device_state()
             if state.network_state == NetworkState.CONNECTED:
+                channel_mask = nwk_config[zigpy.config.CONF_NWK_CHANNELS]
+                await self._api.write_parameter(
+                    NetworkParameter.channel_mask, channel_mask
+                )
                 return
             await asyncio.sleep(CHANGE_NETWORK_WAIT)
         raise Exception("Could not form network.")

--- a/zigpy_deconz/zigbee/application.py
+++ b/zigpy_deconz/zigbee/application.py
@@ -67,23 +67,29 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         await self._api.device_state()
         (ieee,) = await self._api[NetworkParameter.mac_address]
         self._ieee = zigpy.types.EUI64(ieee)
-        await self._api[NetworkParameter.nwk_panid]
-        await self._api[NetworkParameter.nwk_address]
-        await self._api[NetworkParameter.nwk_extended_panid]
-        await self._api[NetworkParameter.channel_mask]
-        await self._api[NetworkParameter.aps_extended_panid]
-        await self._api[NetworkParameter.trust_center_address]
-        await self._api[NetworkParameter.security_mode]
-        await self._api[NetworkParameter.current_channel]
-        await self._api[NetworkParameter.protocol_version]
-        await self._api[NetworkParameter.nwk_update_id]
-        self._api[NetworkParameter.aps_designed_coordinator] = 1
 
         if self._api.protocol_version >= PROTO_VER_WATCHDOG:
             asyncio.ensure_future(self._reset_watchdog())
 
-        if auto_form:
+        (designed_coord,) = await self._api[NetworkParameter.aps_designed_coordinator]
+        device_state, _, _ = await self._api.device_state()
+        should_form = (
+            device_state.network_state != NetworkState.CONNECTED or designed_coord != 1
+        )
+        if auto_form and should_form:
             await self.form_network()
+
+        (self._pan_id,) = await self._api[NetworkParameter.nwk_panid]
+        (self._nwk,) = await self._api[NetworkParameter.nwk_address]
+        (self._ext_pan_id,) = await self._api[NetworkParameter.nwk_extended_panid]
+        await self._api[NetworkParameter.channel_mask]
+        await self._api[NetworkParameter.aps_extended_panid]
+        await self._api[NetworkParameter.trust_center_address]
+        await self._api[NetworkParameter.security_mode]
+        (self._channel,) = await self._api[NetworkParameter.current_channel]
+        await self._api[NetworkParameter.protocol_version]
+        (self._nwk_update_id,) = await self._api[NetworkParameter.nwk_update_id]
+
         coordinator = await DeconzDevice.new(
             self,
             self.ieee,
@@ -104,13 +110,39 @@ class ControllerApplication(zigpy.application.ControllerApplication):
 
     async def form_network(self, channel=15, pan_id=None, extended_pan_id=None):
         LOGGER.info("Forming network")
-        if self._api.network_state == NetworkState.CONNECTED.value:
-            return
+        await self._api.change_network_state(NetworkState.OFFLINE)
+        await self._api.write_parameter(NetworkParameter.aps_designed_coordinator, 1)
 
-        await self._api.change_network_state(NetworkState.CONNECTED.value)
+        nwk_config = self.config[zigpy.config.CONF_NWK]
+
+        # set channel
+        channel = nwk_config[zigpy.config.CONF_NWK_CHANNEL]
+        channel_mask = zigpy.types.Channels.from_channel_list([channel])
+        await self._api.write_parameter(NetworkParameter.channel_mask, channel_mask)
+
+        pan_id = nwk_config[zigpy.config.CONF_NWK_PAN_ID]
+        if pan_id is not None:
+            await self._api.write_parameter(NetworkParameter.nwk_panid, pan_id)
+
+        ext_pan_id = nwk_config[zigpy.config.CONF_NWK_EXTENDED_PAN_ID]
+        if ext_pan_id is not None:
+            await self._api.write_parameter(
+                NetworkParameter.aps_extended_panid, ext_pan_id
+            )
+
+        nwk_update_id = nwk_config[zigpy.config.CONF_NWK_UPDATE_ID]
+        await self._api.write_parameter(NetworkParameter.nwk_update_id, nwk_update_id)
+
+        nwk_key = nwk_config[zigpy.config.CONF_NWK_KEY]
+        if nwk_key is not None:
+            await self._api.write_parameter(NetworkParameter.network_key, 0, nwk_key)
+
+        # bring network up
+        await self._api.change_network_state(NetworkState.CONNECTED)
+
         for _ in range(10):
-            await self._api.device_state()
-            if self._api.network_state == NetworkState.CONNECTED.value:
+            (state, _, _) = await self._api.device_state()
+            if state.network_state == NetworkState.CONNECTED:
                 return
             await asyncio.sleep(CHANGE_NETWORK_WAIT)
         raise Exception("Could not form network.")


### PR DESCRIPTION
Form network only if Offline or `aps_designed_coordinator` is not coordinator.
When forming network, use parameters from zigpy configuration for `channel_mask`, `key`, `pan_id`, `ext_pan_id` etc if present