### PR TITLE
Refactor handling of errors in received data

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -199,18 +199,18 @@ def test_data_received_unk_status(api, monkeypatch):
     my_handler = MagicMock()
 
     for cmd, cmd_opts in deconz_api.RX_COMMANDS.items():
-        _, unsolicited = cmd_opts
+        _, solicited = cmd_opts
         payload = b"\x01\x02\x03\x04"
         status = t.uint8_t(0xFE).serialize()
         data = cmd.serialize() + b"\x00" + status + b"\x00\x00" + payload
         setattr(api, "_handle_{}".format(cmd.name), my_handler)
         api._awaiting[0] = MagicMock()
         api.data_received(data)
-        assert t.deserialize.call_count == 1
-        assert t.deserialize.call_args[0][0] == payload
-        if unsolicited:
+        if solicited:
             assert my_handler.call_count == 0
+            assert t.deserialize.call_count == 0
         else:
+            assert t.deserialize.call_count == 1
             assert my_handler.call_count == 1
         t.deserialize.reset_mock()
         my_handler.reset_mock()

--- a/zigpy_deconz/api.py
+++ b/zigpy_deconz/api.py
@@ -475,9 +475,7 @@ class Deconz:
             )
             return r
         except (asyncio.TimeoutError, zigpy.exceptions.ZigbeeException):
-            pass
-
-        self._data_indication = False
+            self._data_indication = False
 
     def _handle_aps_data_indication(self, data):
         LOGGER.debug("APS data indication response: %s", data)
@@ -539,9 +537,7 @@ class Deconz:
             )
             return r
         except (asyncio.TimeoutError, zigpy.exceptions.ZigbeeException):
-            pass
-
-        self._data_confirm = False
+            self._data_confirm = False
 
     def _handle_add_neighbour(self, data) -> None:
         """Handle add_neighbour response."""

--- a/zigpy_deconz/api.py
+++ b/zigpy_deconz/api.py
@@ -9,6 +9,7 @@ from typing import Any, Callable, Dict, Optional, Tuple
 
 import serial
 from zigpy.config import CONF_DEVICE_PATH
+import zigpy.exceptions
 from zigpy.types import APSStatus, Channels
 
 from zigpy_deconz.exception import APIException, CommandError
@@ -332,14 +333,8 @@ class Deconz:
             status = Status(data[2])
         except ValueError:
             status = data[2]
-        try:
-            data, _ = t.deserialize(data[5:], schema)
-        except Exception as exc:
-            LOGGER.warning("Failed to deserialize frame: %s", binascii.hexlify(data))
-            if solicited and seq in self._awaiting:
-                fut = self._awaiting.pop(seq)
-                fut.set_exception(exc)
-            return
+
+        fut = None
         if solicited and seq in self._awaiting:
             fut = self._awaiting.pop(seq)
             if status != Status.SUCCESS:
@@ -347,6 +342,20 @@ class Deconz:
                     CommandError(status, "%s, status: %s" % (command, status))
                 )
                 return
+
+        try:
+            data, _ = t.deserialize(data[5:], schema)
+        except Exception:
+            LOGGER.warning("Failed to deserialize frame: %s", binascii.hexlify(data))
+            if fut is not None:
+                fut.set_exception(
+                    APIException(
+                        f"Failed to deserialize frame: {binascii.hexlify(data)}"
+                    )
+                )
+            return
+
+        if fut is not None:
             fut.set_result(data)
         getattr(self, "_handle_%s" % (command.name,))(data)
 
@@ -465,8 +474,10 @@ class Deconz:
                 binascii.hexlify(r[8]),
             )
             return r
-        except asyncio.TimeoutError:
-            self._data_indication = False
+        except (asyncio.TimeoutError, zigpy.exceptions.ZigbeeException):
+            pass
+
+        self._data_indication = False
 
     def _handle_aps_data_indication(self, data):
         LOGGER.debug("APS data indication response: %s", data)
@@ -527,8 +538,10 @@ class Deconz:
                 r[5],
             )
             return r
-        except asyncio.TimeoutError:
-            self._data_confirm = False
+        except (asyncio.TimeoutError, zigpy.exceptions.ZigbeeException):
+            pass
+
+        self._data_confirm = False
 
     def _handle_add_neighbour(self, data) -> None:
         """Handle add_neighbour response."""


### PR DESCRIPTION
Refactor handling of errors in received data.
More robust handling of errors for failing `aps_data_confirm` and `aps_data_indication` commands.

Alleviates problems in https://github.com/zigpy/zigpy-deconz/issues/136