### PR TITLE
Update setup.py adding "pyusb>=1.1.0" requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,6 @@ setup(
     author_email="schmidt.d@aon.at",
     license="GPL-3.0",
     packages=find_packages(exclude=["tests"]),
-    install_requires=["pyserial-asyncio", "zigpy>=0.24.0"],
+    install_requires=["pyserial-asyncio", "pyusb>=1.1.0", "zigpy>=0.24.0"],
     tests_require=["pytest", "pytest-asyncio", "asynctest"],
 )


### PR DESCRIPTION
Update setup.py adding "pyusb>=1.1.0" requirement as probably does not hurt have latest pyusb / libusb installed when using USB adapters.

Reference https://github.com/home-assistant/home-assistant.io/pull/15829 and https://github.com/zigpy/zigpy-zigate/issues/71