### PR TITLE
Better handling of delayed or duplicate responses

### DIFF
--- a/zigpy_deconz/api.py
+++ b/zigpy_deconz/api.py
@@ -307,7 +307,7 @@ class Deconz:
                 LOGGER.warning(
                     "No response to '%s' command with seq id '0x%02x'", cmd, seq
                 )
-                self._awaiting.pop(seq)
+                self._awaiting.pop(seq, None)
                 raise
 
     def _api_frame(self, cmd, *args):

--- a/zigpy_deconz/api.py
+++ b/zigpy_deconz/api.py
@@ -9,7 +9,6 @@ from typing import Any, Callable, Dict, Optional, Tuple
 
 import serial
 from zigpy.config import CONF_DEVICE_PATH
-import zigpy.exceptions
 from zigpy.types import APSStatus, Channels
 
 from zigpy_deconz.exception import APIException, CommandError
@@ -485,7 +484,7 @@ class Deconz:
                 binascii.hexlify(r[8]),
             )
             return r
-        except (asyncio.TimeoutError, zigpy.exceptions.ZigbeeException):
+        finally:
             self._data_indication = False
 
     def _handle_aps_data_indication(self, data):
@@ -547,7 +546,7 @@ class Deconz:
                 r[5],
             )
             return r
-        except (asyncio.TimeoutError, zigpy.exceptions.ZigbeeException):
+        finally:
             self._data_confirm = False
 
     def _handle_add_neighbour(self, data) -> None:

--- a/zigpy_deconz/uart.py
+++ b/zigpy_deconz/uart.py
@@ -88,7 +88,10 @@ class Gateway(asyncio.Protocol):
                 continue
 
             LOGGER.debug("Frame received: 0x%s", binascii.hexlify(frame).decode())
-            self._api.data_received(frame)
+            try:
+                self._api.data_received(frame)
+            except Exception as exc:
+                LOGGER.error("Unexpected error handling the frame: %s", exc)
 
     def _unescape(self, data):
         ret = []


### PR DESCRIPTION
Handle delayed or duplicate responses better.
e.g.
```
2021-03-18 15:52:24 DEBUG (MainThread) [zigpy_deconz.uart] Send: 0x17c0000800010001
2021-03-18 15:52:29 DEBUG (MainThread) [zigpy_deconz.uart] Frame received: 0x17c0003b003400220200000102242501040100031d0018460108000030020700002193010300002174b3040000218a4c02408600afd716d51200bd
2021-03-18 15:52:29 ERROR (MainThread) [homeassistant] Error doing job: Exception in callback SerialTransport._read_ready()
Traceback (most recent call last):
File "/usr/local/lib/python3.8/asyncio/events.py", line 81, in _run
self._context.run(self._callback, *self._args)
File "/usr/local/lib/python3.8/site-packages/serial_asyncio/init.py", line 119, in _read_ready
self._protocol.data_received(data)
File "/usr/local/lib/python3.8/site-packages/zigpy_deconz/uart.py", line 91, in data_received
self._api.data_received(frame)
File "/usr/local/lib/python3.8/site-packages/zigpy_deconz/api.py", line 359, in data_received
fut.set_result(data)
asyncio.exceptions.InvalidStateError: invalid state
2021-03-18 15:52:29 WARNING (MainThread) [zigpy_deconz.api] No response to 'Command.aps_data_indication' command with seq id '0xc0'
2021-03-18 15:52:29 ERROR (MainThread) [homeassistant] Error doing job: Task exception was never retrieved
Traceback (most recent call last):
File "/usr/local/lib/python3.8/site-packages/zigpy_deconz/api.py", line 305, in _command
return await asyncio.wait_for(fut, timeout=COMMAND_TIMEOUT)
File "/usr/local/lib/python3.8/asyncio/tasks.py", line 501, in wait_for
raise exceptions.TimeoutError()
asyncio.exceptions.TimeoutError
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
File "/usr/local/lib/python3.8/site-packages/zigpy_deconz/api.py", line 462, in _aps_data_indication
r = await self._command(
File "/usr/local/lib/python3.8/site-packages/zigpy_deconz/api.py", line 310, in _command
self._awaiting.pop(seq)
KeyError: 192
```