### PR TITLE
Add list of compatible hardware to zigpy-deconz README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,20 @@
 [![Build Status](https://travis-ci.org/zigpy/zigpy-deconz.svg?branch=master)](https://travis-ci.org/zigpy/zigpy-deconz)
 [![Coverage](https://coveralls.io/repos/github/zigpy/zigpy-deconz/badge.svg?branch=master)](https://coveralls.io/github/zigpy/zigpy-deconz?branch=master)
 
-[zigpy-deconz](https://github.com/zigpy/zigpy-deconz) is a Python 3 implementation for the [Zigpy](https://github.com/zigpy/) project to implement [deCONZ](https://www.dresden-elektronik.de/funktechnik/products/software/pc/deconz/) based [Zigbee](https://www.zigbee.org) radio devices.
+[zigpy-deconz](https://github.com/zigpy/zigpy-deconz) is a Python 3 radio libary implementation for the [Zigpy](https://github.com/zigpy/) project to implement [deCONZ](https://www.dresden-elektronik.de/funktechnik/products/software/pc/deconz/) based [Zigbee](https://www.zigbee.org) radio devices.
 
 The goal of this project to add native support for the Dresden-Elektronik deCONZ based ZigBee modules in Home Assistant via [Zigpy](https://github.com/zigpy/).
 
 This library uses the deCONZ serial protocol for communicating with [ConBee](https://www.dresden-elektronik.de/conbee/), [ConBee II (ConBee 2)](https://shop.dresden-elektronik.de/conbee-2.html), and [RaspBee](https://www.dresden-elektronik.de/raspbee/) adapters from [Dresden-Elektronik](https://github.com/dresden-elektronik/).
+
+# Hardware requirements
+
+dresden elektronik based radios USB-adapters and GPIO-modules with deCONZ Serial Protocol compatible with zigpy-deconz:
+
+- [ConBee II (a.k.a. ConBee 2)](https://shop.dresden-elektronik.de/conbee-2.html) USB adapter
+- [RaspBee II (a.k.a. RaspBee 2)](https://www.dresden-elektronik.com/product/raspbee-II.html) GPIO radio module
+- [ConBee](https://www.dresden-elektronik.de/conbee/) USB radio adapter
+- [RaspBee](https://www.dresden-elektronik.de/raspbee/) GPIO radio module
 
 # Testing new releases
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/zigpy/zigpy-deconz.svg?branch=master)](https://travis-ci.org/zigpy/zigpy-deconz)
 [![Coverage](https://coveralls.io/repos/github/zigpy/zigpy-deconz/badge.svg?branch=master)](https://coveralls.io/github/zigpy/zigpy-deconz?branch=master)
 
-[zigpy-deconz](https://github.com/zigpy/zigpy-deconz) is a Python 3 radio libary implementation for the [Zigpy](https://github.com/zigpy/) project to implement [deCONZ](https://www.dresden-elektronik.de/funktechnik/products/software/pc/deconz/) based [Zigbee](https://www.zigbee.org) radio devices.
+[zigpy-deconz](https://github.com/zigpy/zigpy-deconz) is a Python 3 radio library implementation for the [Zigpy](https://github.com/zigpy/) project to implement [deCONZ](https://www.dresden-elektronik.de/funktechnik/products/software/pc/deconz/) based [Zigbee](https://www.zigbee.org) radio devices.
 
 The goal of this project to add native support for the Dresden-Elektronik deCONZ based ZigBee modules in Home Assistant via [Zigpy](https://github.com/zigpy/).
 

--- a/README.md
+++ b/README.md
@@ -13,10 +13,11 @@ This library uses the deCONZ serial protocol for communicating with [ConBee](htt
 
 dresden elektronik based radios USB-adapters and GPIO-modules with deCONZ Serial Protocol compatible with zigpy-deconz:
 
-- [ConBee II (a.k.a. ConBee 2)](https://shop.dresden-elektronik.de/conbee-2.html) USB adapter
-- [RaspBee II (a.k.a. RaspBee 2)](https://www.dresden-elektronik.com/product/raspbee-II.html) GPIO radio module
-- [ConBee](https://www.dresden-elektronik.de/conbee/) USB radio adapter
-- [RaspBee](https://www.dresden-elektronik.de/raspbee/) GPIO radio module
+- [ConBee III (a.k.a. ConBee 3)](https://phoscon.de/en/conbee3) USB adapter
+- [ConBee II (a.k.a. ConBee 2)](https://phoscon.de/en/conbee2) USB adapter
+- [ConBee](https://phoscon.de/en/conbee) USB radio adapter
+- [RaspBee II (a.k.a. RaspBee 2)](https://phoscon.de/en/raspbee2) GPIO radio module
+- [RaspBee](https://phoscon.de/en/raspbee) GPIO radio module
 
 # Testing new releases
 


### PR DESCRIPTION
Add a list of compatible hardware to zigpy-deconz README.md as the plan is to remove such a list from zigpy in https://github.com/zigpy/zigpy/pull/705

Downstream project(s) also want such information to be provided by upstream as per https://github.com/home-assistant/home-assistant.io/pull/17089