### PR TITLE
Fix startup error due to `None` node descriptor

### DIFF
--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -621,10 +621,9 @@ async def test_restore_neighbours(app):
     device_2.nwk = 0x2222
     nei_2 = zigpy.neighbor.Neighbor(sentinel.nei_2, device_2)
 
-    # invalid node descriptor
-    desc_3 = zdo_t.NodeDescriptor()
+    # Missing node descriptor
     device_3 = MagicMock()
-    device_3.node_desc = desc_3
+    device_3.node_desc = None
     device_3.ieee = sentinel.ieee_3
     device_3.nwk = 0x3333
     nei_3 = zigpy.neighbor.Neighbor(sentinel.nei_3, device_3)

--- a/zigpy_deconz/zigbee/application.py
+++ b/zigpy_deconz/zigbee/application.py
@@ -345,18 +345,20 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         for device in devices:
             if device is None:
                 continue
+            descr = device.node_desc
             LOGGER.debug(
                 "device: 0x%04x - %s %s, FFD=%s, Rx_on_when_idle=%s",
                 device.nwk,
                 device.manufacturer,
                 device.model,
-                device.node_desc.is_full_function_device,
-                device.node_desc.is_receiver_on_when_idle,
+                descr.is_full_function_device if descr is not None else None,
+                descr.is_receiver_on_when_idle if descr is not None else None,
             )
-            descr = device.node_desc
-            if not descr.is_valid:
-                continue
-            if descr.is_full_function_device or descr.is_receiver_on_when_idle:
+            if (
+                descr is None
+                or descr.is_full_function_device
+                or descr.is_receiver_on_when_idle
+            ):
                 continue
             LOGGER.debug(
                 "Restoring %s/0x%04x device as direct child",


### PR DESCRIPTION
Devices with missing node descriptors cause a startup failure when neighbors are being restored.