### PR TITLE
Load network key data at startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,5 @@ ENV/
 
 # Visual Studio Code
 .vscode
+
+.DS_Store

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,6 @@ setup(
     author_email="schmidt.d@aon.at",
     license="GPL-3.0",
     packages=find_packages(exclude=["tests"]),
-    install_requires=["pyserial-asyncio", "zigpy>=0.37.0"],
+    install_requires=["pyserial-asyncio", "zigpy>=0.40.0"],
     tests_require=["pytest", "pytest-asyncio", "asynctest"],
 )

--- a/zigpy_deconz/api.py
+++ b/zigpy_deconz/api.py
@@ -10,7 +10,7 @@ from typing import Any, Callable, Dict, Optional, Tuple
 import serial
 from zigpy.config import CONF_DEVICE_PATH
 import zigpy.exceptions
-from zigpy.types import APSStatus, Bool, Channels, KeyData
+from zigpy.types import APSStatus, Bool, Channels
 
 from zigpy_deconz.exception import APIException, CommandError
 import zigpy_deconz.types as t
@@ -208,7 +208,7 @@ NETWORK_PARAMETER_SCHEMA_RSP = {
     NetworkParameter.security_mode: (t.uint8_t,),
     NetworkParameter.use_predefined_nwk_panid: (Bool,),
     NetworkParameter.network_key: (t.uint8_t, t.Key),
-    NetworkParameter.link_key: (t.EUI64, KeyData),
+    NetworkParameter.link_key: (t.EUI64, t.Key),
     NetworkParameter.current_channel: (t.uint8_t,),
     NetworkParameter.permit_join: (t.uint8_t,),
     NetworkParameter.protocol_version: (t.uint16_t,),

--- a/zigpy_deconz/zigbee/application.py
+++ b/zigpy_deconz/zigbee/application.py
@@ -119,7 +119,10 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         (self.state.network_information.tc_link_key.partner_ieee,) = await self._api[
             NetworkParameter.trust_center_address
         ]
-        _, self.state.network_information.tc_link_key = await self._api.read_parameter(
+        (
+            _,
+            self.state.network_information.tc_link_key.key,
+        ) = await self._api.read_parameter(
             NetworkParameter.link_key,
             self.state.network_information.tc_link_key.partner_ieee,
         )

--- a/zigpy_deconz/zigbee/application.py
+++ b/zigpy_deconz/zigbee/application.py
@@ -93,11 +93,37 @@ class ControllerApplication(zigpy.application.ControllerApplication):
             NetworkParameter.channel_mask
         ]
         await self._api[NetworkParameter.aps_extended_panid]
+
+        if self.state.network_information.network_key is None:
+            self.state.network_information.network_key = zigpy.state.Key()
+
+        (
+            _,
+            self.state.network_information.network_key.key,
+        ) = await self._api.read_parameter(NetworkParameter.network_key, 0)
+        self.state.network_information.network_key.seq = 0
+        self.state.network_information.network_key.rx_counter = None
+        self.state.network_information.network_key.partner_ieee = None
+
+        try:
+            (self.state.network_information.network_key.tx_counter,) = await self._api[
+                NetworkParameter.nwk_frame_counter
+            ]
+        except zigpy_deconz.exception.CommandError as ex:
+            assert ex.status == Status.UNSUPPORTED
+            self.state.network_information.network_key.tx_counter = None
+
         if self.state.network_information.tc_link_key is None:
             self.state.network_information.tc_link_key = zigpy.state.Key()
+
         (self.state.network_information.tc_link_key.partner_ieee,) = await self._api[
             NetworkParameter.trust_center_address
         ]
+        _, self.state.network_information.tc_link_key = await self._api.read_parameter(
+            NetworkParameter.link_key,
+            self.state.network_information.tc_link_key.partner_ieee,
+        )
+
         (self.state.network_information.security_level,) = await self._api[
             NetworkParameter.security_mode
         ]


### PR DESCRIPTION
Loads the network and trust center link keys during startup into the `state` structure.

The deCONZ serial API documents a R/W "NWK Frame Counter" parameter (0x27) but I'm unable to read it with my Conbee II running the latest firmware.
