### PR TITLE
Implement new radio API

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,3 +20,6 @@ force_sort_within_sections = true
 known_first_party = zigpy_deconz,tests
 forced_separate = tests
 combine_as_imports = true
+
+[tool:pytest]
+asyncio_mode = auto

--- a/setup.py
+++ b/setup.py
@@ -22,5 +22,5 @@ setup(
     license="GPL-3.0",
     packages=find_packages(exclude=["tests"]),
     install_requires=["pyserial-asyncio", "zigpy>=0.40.0"],
-    tests_require=["pytest", "pytest-asyncio", "asynctest"],
+    tests_require=["pytest", "pytest-asyncio>=0.17", "asynctest"],
 )

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,6 @@ setup(
     author_email="schmidt.d@aon.at",
     license="GPL-3.0",
     packages=find_packages(exclude=["tests"]),
-    install_requires=["pyserial-asyncio", "zigpy>=0.40.0"],
+    install_requires=["pyserial-asyncio", "zigpy>=0.47.0"],
     tests_require=["pytest", "pytest-asyncio>=0.17", "asynctest"],
 )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -14,7 +14,6 @@ import zigpy_deconz.zigbee.application
 
 from .async_mock import AsyncMock, MagicMock, patch, sentinel
 
-pytestmark = pytest.mark.asyncio
 DEVICE_CONFIG = {zigpy.config.CONF_DEVICE_PATH: "/dev/null"}
 
 

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -619,14 +619,14 @@ async def test_mrequest_send_aps_data_error(app):
 async def test_reset_watchdog(app):
     """Test watchdog."""
     with patch.object(app._api, "write_parameter") as mock_api:
-        dog = asyncio.ensure_future(app._reset_watchdog())
+        dog = asyncio.create_task(app._reset_watchdog())
         await asyncio.sleep(0.3)
         dog.cancel()
         assert mock_api.call_count == 1
 
     with patch.object(app._api, "write_parameter") as mock_api:
         mock_api.side_effect = zigpy_deconz.exception.CommandError
-        dog = asyncio.ensure_future(app._reset_watchdog())
+        dog = asyncio.create_task(app._reset_watchdog())
         await asyncio.sleep(0.3)
         dog.cancel()
         assert mock_api.call_count == 1

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -795,11 +795,19 @@ ENDPOINT = zdo_t.SimpleDescriptor(
     input_clusters=[4],
     output_clusters=[5],
 )
-INVALID_DESCRIPTOR = zdo_t.SimpleDescriptor(
+INVALID_DESCRIPTOR1 = zdo_t.SimpleDescriptor(
     endpoint=184,
     profile=7329,
     device_type=19200,
     device_version=18,
+    input_clusters=[],
+    output_clusters=[],
+)
+INVALID_DESCRIPTOR2 = zdo_t.SimpleDescriptor(
+    endpoint=80,
+    profile=56832,
+    device_type=1,
+    device_version=1,
     input_clusters=[],
     output_clusters=[],
 )
@@ -813,13 +821,13 @@ INVALID_DESCRIPTOR = zdo_t.SimpleDescriptor(
         # Target the first invalid endpoint ID
         (
             ENDPOINT.replace(endpoint=184),
-            {0: None, 1: INVALID_DESCRIPTOR, 2: INVALID_DESCRIPTOR},
+            {0: None, 1: INVALID_DESCRIPTOR1, 2: INVALID_DESCRIPTOR2},
             1,
         ),
         # Target the endpoint with the same ID
         (
             ENDPOINT.replace(endpoint=1),
-            {0: None, 1: INVALID_DESCRIPTOR, 2: ENDPOINT.replace(endpoint=1)},
+            {0: None, 1: INVALID_DESCRIPTOR1, 2: ENDPOINT.replace(endpoint=1)},
             2,
         ),
         # No free endpoint slots, this is an error

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -234,6 +234,7 @@ def test_rx_unknown_device(app, addr_ieee, addr_nwk, caplog):
 async def test_start_network(app, proto_ver, nwk_state, error):
     app.load_network_info = AsyncMock()
     app.restore_neighbours = AsyncMock()
+    app.add_endpoint = AsyncMock()
     app._change_network_state = AsyncMock(side_effect=error)
 
     app._api.device_state = AsyncMock(

--- a/tests/test_network_state.py
+++ b/tests/test_network_state.py
@@ -1,0 +1,290 @@
+"""Test `load_network_info` and `write_network_info` methods."""
+
+import pytest
+from zigpy.exceptions import NetworkNotFormed
+import zigpy.state as app_state
+import zigpy.types as t
+import zigpy.zdo.types as zdo_t
+
+import zigpy_deconz.api
+import zigpy_deconz.exception
+import zigpy_deconz.zigbee.application as application
+
+from tests.async_mock import AsyncMock, patch
+from tests.test_application import api, app, device_path  # noqa: F401
+
+
+def merge_objects(obj: object, update: dict) -> None:
+    for key, value in update.items():
+        if "." not in key:
+            setattr(obj, key, value)
+        else:
+            subkey, rest = key.split(".", 1)
+            merge_objects(getattr(obj, subkey), {rest: value})
+
+
+@pytest.fixture
+def node_info():
+    return app_state.NodeInfo(
+        nwk=t.NWK(0x0000),
+        ieee=t.EUI64.convert("93:2C:A9:34:D9:D0:5D:12"),
+        logical_type=zdo_t.LogicalType.Coordinator,
+    )
+
+
+@pytest.fixture
+def network_info(node_info):
+    return app_state.NetworkInfo(
+        extended_pan_id=t.ExtendedPanId.convert("0D:49:91:99:AE:CD:3C:35"),
+        pan_id=t.PanId(0x9BB0),
+        nwk_update_id=0x12,
+        nwk_manager_id=t.NWK(0x0000),
+        channel=t.uint8_t(15),
+        channel_mask=t.Channels.from_channel_list([15, 20, 25]),
+        security_level=t.uint8_t(5),
+        network_key=app_state.Key(
+            key=t.KeyData.convert("9A:79:D6:9A:DA:EC:45:C6:F2:EF:EB:AF:DA:A3:07:B6"),
+            seq=108,
+            tx_counter=39009277,
+        ),
+        tc_link_key=app_state.Key(
+            key=t.KeyData(b"ZigBeeAlliance09"),
+            partner_ieee=node_info.ieee,
+            tx_counter=8712428,
+        ),
+        key_table=[],
+        children=[],
+        nwk_addresses={},
+        stack_specific={},
+    )
+
+
+@patch.object(application, "CHANGE_NETWORK_WAIT", 0.001)
+@pytest.mark.parametrize(
+    "channel_mask, channel, security_level, fw_supports_fc, logical_type",
+    [
+        (
+            t.Channels.from_channel_list([15]),
+            15,
+            0,
+            True,
+            zdo_t.LogicalType.Coordinator,
+        ),
+        (
+            t.Channels.from_channel_list([15]),
+            15,
+            0,
+            False,
+            zdo_t.LogicalType.Coordinator,
+        ),
+        (
+            t.Channels.from_channel_list([15, 20]),
+            15,
+            5,
+            True,
+            zdo_t.LogicalType.Coordinator,
+        ),
+        (
+            t.Channels.from_channel_list([15, 20, 25]),
+            None,
+            5,
+            True,
+            zdo_t.LogicalType.Router,
+        ),
+        (None, 15, 5, True, zdo_t.LogicalType.Coordinator),
+    ],
+)
+async def test_write_network_info(
+    app,  # noqa: F811
+    network_info,
+    node_info,
+    channel_mask,
+    channel,
+    security_level,
+    fw_supports_fc,
+    logical_type,
+):
+    """Test that network info is correctly written."""
+
+    params = {}
+
+    async def write_parameter(param, *args):
+        if (
+            not fw_supports_fc
+            and param == zigpy_deconz.api.NetworkParameter.nwk_frame_counter
+        ):
+            raise zigpy_deconz.exception.CommandError(
+                status=zigpy_deconz.api.Status.UNSUPPORTED
+            )
+
+        params[param.name] = args
+
+    app._api.write_parameter = AsyncMock(side_effect=write_parameter)
+
+    network_info = network_info.replace(
+        channel=channel,
+        channel_mask=channel_mask,
+        security_level=security_level,
+    )
+
+    node_info = node_info.replace(logical_type=logical_type)
+
+    await app.write_network_info(
+        network_info=network_info,
+        node_info=node_info,
+    )
+
+    params = {
+        call[0][0].name: call[0][1:]
+        for call in app._api.write_parameter.await_args_list
+    }
+
+    assert params["nwk_frame_counter"] == (network_info.network_key.tx_counter,)
+
+    if node_info.logical_type == zdo_t.LogicalType.Coordinator:
+        assert params["aps_designed_coordinator"] == (1,)
+    else:
+        assert params["aps_designed_coordinator"] == (0,)
+
+    assert params["nwk_address"] == (node_info.nwk,)
+    assert params["mac_address"] == (node_info.ieee,)
+
+    if channel is not None:
+        assert params["channel_mask"] == (
+            t.Channels.from_channel_list([network_info.channel]),
+        )
+    elif channel_mask is not None:
+        assert params["channel_mask"] == (network_info.channel_mask,)
+    else:
+        assert False
+
+    assert params["use_predefined_nwk_panid"] == (True,)
+    assert params["nwk_panid"] == (network_info.pan_id,)
+    assert params["aps_extended_panid"] == (network_info.extended_pan_id,)
+    assert params["nwk_update_id"] == (network_info.nwk_update_id,)
+    assert params["network_key"] == (0, network_info.network_key.key)
+    assert params["trust_center_address"] == (node_info.ieee,)
+    assert params["link_key"] == (node_info.ieee, network_info.tc_link_key.key)
+
+    if security_level == 0:
+        assert params["security_mode"] == (zigpy_deconz.api.SecurityMode.NO_SECURITY,)
+    else:
+        assert params["security_mode"] == (zigpy_deconz.api.SecurityMode.ONLY_TCLK,)
+
+
+@patch.object(application, "CHANGE_NETWORK_WAIT", 0.001)
+@pytest.mark.parametrize(
+    "error, param_overrides, nwk_state_changes, node_state_changes",
+    [
+        (None, {}, {}, {}),
+        (
+            None,
+            {("aps_designed_coordinator",): [0x00]},
+            {},
+            {"logical_type": zdo_t.LogicalType.Router},
+        ),
+        (
+            None,
+            {
+                ("aps_extended_panid",): [t.EUI64.convert("00:00:00:00:00:00:00:00")],
+                ("nwk_extended_panid",): [t.EUI64.convert("0D:49:91:99:AE:CD:3C:35")],
+            },
+            {},
+            {},
+        ),
+        (NetworkNotFormed, {("current_channel",): [0]}, {}, {}),
+        (
+            None,
+            {
+                ("nwk_frame_counter",): zigpy_deconz.exception.CommandError(
+                    zigpy_deconz.api.Status.UNSUPPORTED
+                )
+            },
+            {"network_key.tx_counter": 0},
+            {},
+        ),
+        (
+            None,
+            {("security_mode",): [zigpy_deconz.api.SecurityMode.NO_SECURITY]},
+            {"security_level": 0},
+            {},
+        ),
+        (
+            None,
+            {
+                ("security_mode",): [
+                    zigpy_deconz.api.SecurityMode.PRECONFIGURED_NETWORK_KEY
+                ]
+            },
+            {"security_level": 5},
+            {},
+        ),
+    ],
+)
+async def test_load_network_info(
+    app,  # noqa: F811
+    network_info,
+    node_info,
+    error,
+    param_overrides,
+    nwk_state_changes,
+    node_state_changes,
+):
+    """Test that network info is correctly read."""
+
+    params = {
+        ("nwk_frame_counter",): [network_info.network_key.tx_counter],
+        ("aps_designed_coordinator",): [1],
+        ("nwk_address",): [node_info.nwk],
+        ("mac_address",): [node_info.ieee],
+        ("current_channel",): [network_info.channel],
+        ("channel_mask",): [t.Channels.from_channel_list([network_info.channel])],
+        ("use_predefined_nwk_panid",): [True],
+        ("nwk_panid",): [network_info.pan_id],
+        ("aps_extended_panid",): [network_info.extended_pan_id],
+        ("nwk_update_id",): [network_info.nwk_update_id],
+        ("network_key", 0): [0, network_info.network_key.key],
+        ("trust_center_address",): [node_info.ieee],
+        ("link_key", node_info.ieee): [node_info.ieee, network_info.tc_link_key.key],
+        ("security_mode",): [zigpy_deconz.api.SecurityMode.ONLY_TCLK],
+    }
+
+    params.update(param_overrides)
+
+    async def read_param(param, *args):
+        try:
+            value = params[(param.name,) + args]
+        except KeyError:
+            raise zigpy_deconz.exception.CommandError(
+                zigpy_deconz.api.Status.UNSUPPORTED, f"Unsupported: {param!r} {args!r}"
+            )
+
+        if isinstance(value, Exception):
+            raise value
+
+        return value
+
+    app._api.__getitem__ = app._api.read_parameter = AsyncMock(side_effect=read_param)
+
+    if error is not None:
+        with pytest.raises(error):
+            await app.load_network_info()
+
+        return
+
+    assert app.state.network_info != network_info
+    assert app.state.node_info != node_info
+
+    await app.load_network_info()
+
+    # Almost all of the info matches
+    network_info = network_info.replace(
+        channel_mask=t.Channels.from_channel_list([network_info.channel]),
+        network_key=network_info.network_key.replace(seq=0),
+        tc_link_key=network_info.tc_link_key.replace(tx_counter=0),
+    )
+    merge_objects(network_info, nwk_state_changes)
+
+    assert app.state.network_info == network_info
+
+    assert app.state.node_info == node_info.replace(**node_state_changes)

--- a/tests/test_network_state.py
+++ b/tests/test_network_state.py
@@ -6,6 +6,7 @@ import zigpy.state as app_state
 import zigpy.types as t
 import zigpy.zdo.types as zdo_t
 
+import zigpy_deconz
 import zigpy_deconz.api
 import zigpy_deconz.exception
 import zigpy_deconz.zigbee.application as application
@@ -56,6 +57,12 @@ def network_info(node_info):
         children=[],
         nwk_addresses={},
         stack_specific={},
+        source=f"zigpy-deconz@{zigpy_deconz.__version__}",
+        metadata={
+            "deconz": {
+                "version": 0,
+            }
+        },
     )
 
 

--- a/zigpy_deconz/api.py
+++ b/zigpy_deconz/api.py
@@ -7,7 +7,7 @@ import binascii
 import enum
 import functools
 import logging
-from typing import Any, Callable, Dict, Optional, Tuple
+from typing import Any, Callable, Optional
 
 import serial
 from zigpy.config import CONF_DEVICE_PATH
@@ -43,7 +43,7 @@ class DeviceState(enum.IntFlag):
     APSDE_DATA_REQUEST_SLOTS_AVAILABLE = 0x20
 
     @classmethod
-    def deserialize(cls, data) -> Tuple["DeviceState", bytes]:
+    def deserialize(cls, data) -> tuple["DeviceState", bytes]:
         """Deserialize DevceState."""
         state, data = t.uint8_t.deserialize(data)
         return cls(state), data
@@ -227,7 +227,7 @@ NETWORK_PARAMETER_SCHEMA = {
 class Deconz:
     """deCONZ API class."""
 
-    def __init__(self, app: Callable, device_config: Dict[str, Any]):
+    def __init__(self, app: Callable, device_config: dict[str, Any]):
         """Init instance."""
         self._app = app
         self._aps_data_ind_flags: int = 0x01
@@ -402,7 +402,7 @@ class Deconz:
         LOGGER.debug("Change network state response: %s", NetworkState(data[0]).name)
 
     @classmethod
-    async def probe(cls, device_config: Dict[str, Any]) -> bool:
+    async def probe(cls, device_config: dict[str, Any]) -> bool:
         """Probe port for the device presence."""
         api = cls(None, device_config)
         try:
@@ -644,10 +644,10 @@ class Deconz:
             LOGGER.debug("Data request queue full.")
         if DeviceState.APSDE_DATA_INDICATION in state and not self._data_indication:
             self._data_indication = True
-            asyncio.ensure_future(self._aps_data_indication())
+            asyncio.create_task(self._aps_data_indication())
         if DeviceState.APSDE_DATA_CONFIRM in state and not self._data_confirm:
             self._data_confirm = True
-            asyncio.ensure_future(self._aps_data_confirm())
+            asyncio.create_task(self._aps_data_confirm())
 
     def __getitem__(self, key):
         """Access parameters via getitem."""
@@ -655,4 +655,4 @@ class Deconz:
 
     def __setitem__(self, key, value):
         """Set parameters via setitem."""
-        return asyncio.ensure_future(self.write_parameter(key, value))
+        return asyncio.create_task(self.write_parameter(key, value))

--- a/zigpy_deconz/api.py
+++ b/zigpy_deconz/api.py
@@ -73,6 +73,11 @@ class SecurityMode(t.uint8_t, enum.Enum):
     ONLY_TCLK = 0x03
 
 
+class ZDPResponseHandling(t.bitmap16):
+    NONE = 0x0000
+    NodeDescRsp = 0x0001
+
+
 class Command(t.uint8_t, enum.Enum):
     aps_data_confirm = 0x04
     device_state = 0x07
@@ -223,7 +228,7 @@ NETWORK_PARAMETER_SCHEMA = {
     NetworkParameter.nwk_update_id: (t.uint8_t,),
     NetworkParameter.watchdog_ttl: (t.uint32_t,),
     NetworkParameter.nwk_frame_counter: (t.uint32_t,),
-    NetworkParameter.app_zdp_response_handling: (t.uint16_t,),
+    NetworkParameter.app_zdp_response_handling: (ZDPResponseHandling,),
 }
 
 

--- a/zigpy_deconz/api.py
+++ b/zigpy_deconz/api.py
@@ -13,6 +13,7 @@ import serial
 from zigpy.config import CONF_DEVICE_PATH
 import zigpy.exceptions
 from zigpy.types import APSStatus, Bool, Channels
+from zigpy.zdo.types import SimpleDescriptor
 
 from zigpy_deconz.exception import APIException, CommandError
 import zigpy_deconz.types as t
@@ -189,6 +190,7 @@ class NetworkParameter(t.uint8_t, enum.Enum):
     aps_extended_panid = 0x0B
     trust_center_address = 0x0E
     security_mode = 0x10
+    configure_endpoint = 0x13
     use_predefined_nwk_panid = 0x15
     network_key = 0x18
     link_key = 0x19
@@ -216,6 +218,7 @@ NETWORK_PARAMETER_SCHEMA = {
     NetworkParameter.link_key: (t.EUI64, t.Key),
     NetworkParameter.current_channel: (t.uint8_t,),
     NetworkParameter.permit_join: (t.uint8_t,),
+    NetworkParameter.configure_endpoint: (t.uint8_t, SimpleDescriptor),
     NetworkParameter.protocol_version: (t.uint16_t,),
     NetworkParameter.nwk_update_id: (t.uint8_t,),
     NetworkParameter.watchdog_ttl: (t.uint32_t,),

--- a/zigpy_deconz/api.py
+++ b/zigpy_deconz/api.py
@@ -63,6 +63,13 @@ class NetworkState(t.uint8_t, enum.Enum):
     LEAVING = 3
 
 
+class SecurityMode(t.uint8_t, enum.Enum):
+    NO_SECURITY = 0x00
+    PRECONFIGURED_NETWORK_KEY = 0x01
+    NETWORK_KEY_FROM_TC = 0x02
+    ONLY_TCLK = 0x03
+
+
 class Command(t.uint8_t, enum.Enum):
     aps_data_confirm = 0x04
     device_state = 0x07

--- a/zigpy_deconz/api.py
+++ b/zigpy_deconz/api.py
@@ -280,7 +280,7 @@ class Deconz:
         self._uart = None
         if self._conn_lost_task and not self._conn_lost_task.done():
             self._conn_lost_task.cancel()
-        self._conn_lost_task = asyncio.ensure_future(self._connection_lost())
+        self._conn_lost_task = asyncio.create_task(self._connection_lost())
 
     async def _connection_lost(self) -> None:
         """Reconnect serial port."""

--- a/zigpy_deconz/api.py
+++ b/zigpy_deconz/api.py
@@ -1,5 +1,7 @@
 """deCONZ serial protocol API."""
 
+from __future__ import annotations
+
 import asyncio
 import binascii
 import enum

--- a/zigpy_deconz/types.py
+++ b/zigpy_deconz/types.py
@@ -149,6 +149,10 @@ class bitmap8(bitmap_factory(uint8_t)):
     pass
 
 
+class bitmap16(bitmap_factory(uint16_t)):
+    pass
+
+
 class DeconzSendDataFlags(bitmap8):
     NONE = 0x00
     NODE_ID = 0x01

--- a/zigpy_deconz/uart.py
+++ b/zigpy_deconz/uart.py
@@ -91,7 +91,7 @@ class Gateway(asyncio.Protocol):
             try:
                 self._api.data_received(frame)
             except Exception as exc:
-                LOGGER.error("Unexpected error handling the frame: %s", exc)
+                LOGGER.error("Unexpected error handling the frame", exc_info=exc)
 
     def _unescape(self, data):
         ret = []

--- a/zigpy_deconz/zigbee/application.py
+++ b/zigpy_deconz/zigbee/application.py
@@ -100,7 +100,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
 
         try:
             if self._api.protocol_version >= PROTO_VER_WATCHDOG:
-                await self._api.write_parameter(NetworkParameter.watchdog_ttl, 0)
+                await self._api.write_parameter(NetworkParameter.watchdog_ttl, 1)
         except zigpy_deconz.exception.CommandError:
             pass
         finally:

--- a/zigpy_deconz/zigbee/application.py
+++ b/zigpy_deconz/zigbee/application.py
@@ -205,70 +205,67 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         if device_state.network_state != NetworkState.CONNECTED:
             raise NetworkNotFormed()
 
+        network_info = self.state.network_info
+        node_info = self.state.node_info
+
         (ieee,) = await self._api[NetworkParameter.mac_address]
-        self.state.node_info.ieee = zigpy.types.EUI64(ieee)
+        node_info.ieee = zigpy.types.EUI64(ieee)
 
         (designed_coord,) = await self._api[NetworkParameter.aps_designed_coordinator]
 
         if designed_coord == 0x01:
-            self.state.node_info.logical_type = zdo_t.LogicalType.Coordinator
+            node_info.logical_type = zdo_t.LogicalType.Coordinator
         else:
-            self.state.node_info.logical_type = zdo_t.LogicalType.Router
+            node_info.logical_type = zdo_t.LogicalType.Router
 
-        (self.state.node_info.nwk,) = await self._api[NetworkParameter.nwk_address]
+        (node_info.nwk,) = await self._api[NetworkParameter.nwk_address]
 
-        (self.state.network_info.pan_id,) = await self._api[NetworkParameter.nwk_panid]
-        (self.state.network_info.extended_pan_id,) = await self._api[
+        (network_info.pan_id,) = await self._api[NetworkParameter.nwk_panid]
+        (network_info.extended_pan_id,) = await self._api[
             NetworkParameter.nwk_extended_panid
         ]
-        (self.state.network_info.channel_mask,) = await self._api[
-            NetworkParameter.channel_mask
-        ]
+        (network_info.channel_mask,) = await self._api[NetworkParameter.channel_mask]
         await self._api[NetworkParameter.aps_extended_panid]
 
-        if self.state.network_info.network_key is None:
-            self.state.network_info.network_key = zigpy.state.Key()
+        if network_info.network_key is None:
+            network_info.network_key = zigpy.state.Key()
 
         (
             _,
-            self.state.network_info.network_key.key,
+            network_info.network_key.key,
         ) = await self._api.read_parameter(NetworkParameter.network_key, 0)
-        self.state.network_info.network_key.seq = 0
-        self.state.network_info.network_key.rx_counter = None
-        self.state.network_info.network_key.partner_ieee = None
+        network_info.network_key.seq = 0
+        network_info.network_key.rx_counter = None
+        network_info.network_key.partner_ieee = None
 
         try:
-            (self.state.network_info.network_key.tx_counter,) = await self._api[
+            (network_info.network_key.tx_counter,) = await self._api[
                 NetworkParameter.nwk_frame_counter
             ]
         except zigpy_deconz.exception.CommandError as ex:
             assert ex.status == Status.UNSUPPORTED
-            self.state.network_info.network_key.tx_counter = None
+            network_info.network_key.tx_counter = None
 
-        if self.state.network_info.tc_link_key is None:
-            self.state.network_info.tc_link_key = zigpy.state.Key()
+        if network_info.tc_link_key is None:
+            network_info.tc_link_key = zigpy.state.Key()
 
-        (self.state.network_info.tc_link_key.partner_ieee,) = await self._api[
+        (network_info.tc_link_key.partner_ieee,) = await self._api[
             NetworkParameter.trust_center_address
         ]
-        (_, self.state.network_info.tc_link_key.key,) = await self._api.read_parameter(
+        (_, network_info.tc_link_key.key,) = await self._api.read_parameter(
             NetworkParameter.link_key,
-            self.state.network_info.tc_link_key.partner_ieee,
+            network_info.tc_link_key.partner_ieee,
         )
 
         (security_mode,) = await self._api[NetworkParameter.security_mode]
 
         if security_mode == SecurityMode.NO_SECURITY:
-            self.state.network_info.security_level = 0x00
+            network_info.security_level = 0x00
         else:
-            self.state.network_info.security_level = 0x05
+            network_info.security_level = 0x05
 
-        (self.state.network_info.channel,) = await self._api[
-            NetworkParameter.current_channel
-        ]
-        (self.state.network_info.nwk_update_id,) = await self._api[
-            NetworkParameter.nwk_update_id
-        ]
+        (network_info.channel,) = await self._api[NetworkParameter.current_channel]
+        (network_info.nwk_update_id,) = await self._api[NetworkParameter.nwk_update_id]
 
     async def force_remove(self, dev):
         """Forcibly remove device from NCP."""

--- a/zigpy_deconz/zigbee/application.py
+++ b/zigpy_deconz/zigbee/application.py
@@ -75,6 +75,9 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         if self._reset_watchdog_task is not None:
             self._reset_watchdog_task.cancel()
 
+        if self._api is None:
+            return
+
         try:
             if self._api.protocol_version >= PROTO_VER_WATCHDOG:
                 await self._api.write_parameter(NetworkParameter.watchdog_ttl, 0)

--- a/zigpy_deconz/zigbee/application.py
+++ b/zigpy_deconz/zigbee/application.py
@@ -22,6 +22,7 @@ import zigpy.types
 import zigpy.util
 import zigpy.zdo.types as zdo_t
 
+import zigpy_deconz
 from zigpy_deconz import types as t
 from zigpy_deconz.api import (
     Deconz,
@@ -256,6 +257,13 @@ class ControllerApplication(zigpy.application.ControllerApplication):
     async def load_network_info(self, *, load_devices=False):
         network_info = self.state.network_info
         node_info = self.state.node_info
+
+        network_info.source = f"zigpy-deconz@{zigpy_deconz.__version__}"
+        network_info.metadata = {
+            "deconz": {
+                "version": self.version,
+            }
+        }
 
         (ieee,) = await self._api[NetworkParameter.mac_address]
         node_info.ieee = zigpy.types.EUI64(ieee)

--- a/zigpy_deconz/zigbee/application.py
+++ b/zigpy_deconz/zigbee/application.py
@@ -158,7 +158,13 @@ class ControllerApplication(zigpy.application.ControllerApplication):
             )
 
         await self._api.write_parameter(NetworkParameter.nwk_address, node_info.nwk)
-        await self._api.write_parameter(NetworkParameter.mac_address, node_info.ieee)
+
+        if node_info.ieee != zigpy.types.EUI64.UNKNOWN:
+            # TODO: is there a way to revert it back to the hardware default? Or is this
+            #       information lost when the parameter is overwritten?
+            await self._api.write_parameter(
+                NetworkParameter.mac_address, node_info.ieee
+            )
 
         # There is no way to specify both a mask and the logical channel
         if network_info.channel is not None:

--- a/zigpy_deconz/zigbee/application.py
+++ b/zigpy_deconz/zigbee/application.py
@@ -361,7 +361,6 @@ class ControllerApplication(zigpy.application.ControllerApplication):
                     # Or one with the "invalid" value
                     not current_descriptor.input_clusters
                     and not current_descriptor.output_clusters
-                    and current_descriptor.device_type == 19200
                 )
             ) and target_index is None:
                 # Pick the first free slot

--- a/zigpy_deconz/zigbee/application.py
+++ b/zigpy_deconz/zigbee/application.py
@@ -462,7 +462,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
 
     async def restore_neighbours(self) -> None:
         """Restore children."""
-        coord = self.get_device(ieee=self.ieee)
+        coord = self.get_device(ieee=self.state.node_info.ieee)
         devices = (nei.device for nei in coord.neighbors)
         for device in devices:
             if device is None:
@@ -494,7 +494,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
     async def _delayed_neighbour_scan(self) -> None:
         """Scan coordinator's neighbours."""
         await asyncio.sleep(DELAY_NEIGHBOUR_SCAN_S)
-        coord = self.get_device(ieee=self.ieee)
+        coord = self.get_device(ieee=self.state.node_info.ieee)
         await coord.neighbors.scan()
 
 

--- a/zigpy_deconz/zigbee/application.py
+++ b/zigpy_deconz/zigbee/application.py
@@ -287,14 +287,14 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         except zigpy_deconz.exception.CommandError as ex:
             assert ex.status == Status.UNSUPPORTED
 
-        (network_info.tc_address,) = await self._api[
+        network_info.tc_link_key = zigpy.state.Key()
+        (network_info.tc_link_key.partner_ieee,) = await self._api[
             NetworkParameter.trust_center_address
         ]
 
-        network_info.tc_link_key = zigpy.state.Key()
         (_, network_info.tc_link_key.key,) = await self._api.read_parameter(
             NetworkParameter.link_key,
-            network_info.tc_address,
+            network_info.tc_link_key.partner_ieee,
         )
 
         (security_mode,) = await self._api[NetworkParameter.security_mode]

--- a/zigpy_deconz/zigbee/application.py
+++ b/zigpy_deconz/zigbee/application.py
@@ -120,20 +120,21 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         await self._api.write_parameter(NetworkParameter.mac_address, node_info.ieee)
 
         # No way to specify both a mask and the logical channel
-        logical_channel_mask = zigpy.types.Channels.from_channel_list(
-            [network_info.channel]
-        )
-
-        if logical_channel_mask != network_info.channel_mask:
-            LOGGER.warning(
-                "Channel mask %s will be replaced with current logical channel %s",
-                network_info.channel_mask,
-                logical_channel_mask,
+        if network_info.channel is not None:
+            channel_mask = zigpy.types.Channels.from_channel_list(
+                [network_info.channel]
             )
 
-        await self._api.write_parameter(
-            NetworkParameter.channel_mask, logical_channel_mask
-        )
+            if channel_mask != network_info.channel_mask:
+                LOGGER.warning(
+                    "Channel mask %s will be replaced with current logical channel %s",
+                    network_info.channel_mask,
+                    channel_mask,
+                )
+        else:
+            channel_mask = network_info.channel_mask
+
+        await self._api.write_parameter(NetworkParameter.channel_mask, channel_mask)
         await self._api.write_parameter(NetworkParameter.nwk_panid, network_info.pan_id)
         await self._api.write_parameter(
             NetworkParameter.aps_extended_panid, network_info.extended_pan_id

--- a/zigpy_deconz/zigbee/application.py
+++ b/zigpy_deconz/zigbee/application.py
@@ -88,17 +88,18 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         raise NotImplementedError()
 
     async def start_network(self):
+        await self.load_network_info(load_devices=False)
 
         coordinator = await DeconzDevice.new(
             self,
-            self.ieee,
-            self.nwk,
+            self.state.node_info.ieee,
+            self.state.node_info.nwk,
             self.version,
             self._config[zigpy.config.CONF_DEVICE][zigpy.config.CONF_DEVICE_PATH],
         )
 
         coordinator.neighbors.add_context_listener(self._dblistener)
-        self.devices[self.ieee] = coordinator
+        self.devices[self.state.node_info.ieee] = coordinator
         if self._api.protocol_version >= PROTO_VER_NEIGBOURS:
             await self.restore_neighbours()
         asyncio.create_task(self._delayed_neighbour_scan())


### PR DESCRIPTION
https://github.com/zigpy/zigpy/pull/848

So far the only data that's "lost" during migration is the channel mask if it isn't just a single channel.  This isn't a problem for coordinators and can be addressed if we ever support router mode.

I was able to migrate my network from a ZZH to a Conbee II with fairly boilerplate code:

```Python
import coloredlogs
coloredlogs.install(level="DEBUG")

from zigpy_deconz.zigbee.application import ControllerApplication as DeconzControllerApplication
from zigpy_znp.zigbee.application import ControllerApplication as ZNPControllerApplication

znp_config = ZNPControllerApplication.SCHEMA({"device": {"path": "/dev/..."}})
deconz_config = DeconzControllerApplication.SCHEMA({"device": {"path": "/dev/..."}})

znp = ZNPControllerApplication(znp_config)
deconz = DeconzControllerApplication(deconz_config)

await znp.connect()
await deconz.connect()

# Perhaps it would be better to have this method return a tuple instead of changing attributes?
await znp.load_network_info(load_devices=True)
await deconz.write_network_info(network_info=znp.state.network_info, node_info=znp.state.node_info)

await znp.disconnect()
await deconz.disconnect()
```