### PR TITLE
Add support for tcp forwarded serial ports

### DIFF
--- a/zigpy_deconz/uart.py
+++ b/zigpy_deconz/uart.py
@@ -141,8 +141,10 @@ async def connect(config: Dict[str, str], api: Callable, loop=None) -> Gateway:
     protocol = Gateway(api, connected_future)
 
     parsed_path = urllib.parse.urlparse(config[CONF_DEVICE_PATH])
-    if parsed_path.scheme == 'tcp':
-        _, protocol = await loop.create_connection(lambda: protocol, parsed_path.hostname, parsed_path.port)
+    if parsed_path.scheme == "tcp":
+        _, protocol = await loop.create_connection(
+            lambda: protocol, parsed_path.hostname, parsed_path.port
+        )
     else:
         _, protocol = await serial_asyncio.create_serial_connection(
             loop,


### PR DESCRIPTION
This allows users to connect to deCONZ Zigbee radio devices that are forwarded via network e.g. with `ser2net` or `socat` by specifying a custom path in the format tcp://host:port.

Tested and working for 2 weeks over a VPN connection. Daily disconnections by the ISP, short-term high latency and other connections issues did not cause any major issues.

If this is accepted, I can add instructions and a working configuration example to the [documentation](https://github.com/home-assistant/home-assistant.io/blob/current/source/_integrations/zha.markdown).