### PR TITLE
Use manual source routes when retrying and enable APS ACKs

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import binascii
+import enum
 import logging
 
 import pytest
@@ -146,13 +147,15 @@ async def test_command_not_connected(api):
 
 
 def _fake_args(arg_type):
-    if isinstance(arg_type(), t.DeconzAddressEndpoint):
+    if issubclass(arg_type, enum.Enum):
+        return list(arg_type)[0]  # Pick the first enum value
+    elif issubclass(arg_type, t.DeconzAddressEndpoint):
         addr = t.DeconzAddressEndpoint()
         addr.address_mode = t.ADDRESS_MODE.NWK
         addr.address = t.uint8_t(0)
         addr.endpoint = t.uint8_t(0)
         return addr
-    if isinstance(arg_type(), t.EUI64):
+    elif issubclass(arg_type, t.EUI64):
         return t.EUI64([0x01] * 8)
 
     return arg_type()

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -318,7 +318,18 @@ async def test_permit(app, nwk):
 async def _test_request(app, send_success=True, aps_data_error=False, **kwargs):
     seq = 123
 
-    async def req_mock(req_id, dst_addr_ep, profile, cluster, src_ep, data):
+    async def req_mock(
+        req_id,
+        dst_addr_ep,
+        profile,
+        cluster,
+        src_ep,
+        data,
+        *,
+        relays=None,
+        tx_options=t.DeconzTransmitOptions.USE_NWK_KEY_SECURITY,
+        radius=0
+    ):
         if aps_data_error:
             raise zigpy_deconz.exception.CommandError(1, "Command Error")
         if send_success:

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -315,7 +315,7 @@ async def test_permit(app, nwk):
     assert app._api.write_parameter.call_args_list[0][0][1] == time_s
 
 
-async def _test_request(app, send_success=True, aps_data_error=False, **kwargs):
+async def _test_request(app, *, send_success=True, aps_data_error=False, **kwargs):
     seq = 123
 
     async def req_mock(
@@ -348,25 +348,59 @@ async def _test_request(app, send_success=True, aps_data_error=False, **kwargs):
 async def test_request_send_success(app):
     req_id = sentinel.req_id
     app.get_sequence = MagicMock(return_value=req_id)
-    r = await _test_request(app, True)
+    r = await _test_request(app, send_success=True)
     assert r[0] == 0
 
-    r = await _test_request(app, True, use_ieee=True)
+    r = await _test_request(app, send_success=True, use_ieee=True)
     assert r[0] == 0
 
 
 async def test_request_send_fail(app):
     req_id = sentinel.req_id
     app.get_sequence = MagicMock(return_value=req_id)
-    r = await _test_request(app, False)
+    r = await _test_request(app, send_success=False)
     assert r[0] != 0
 
 
 async def test_request_send_aps_data_error(app):
     req_id = sentinel.req_id
     app.get_sequence = MagicMock(return_value=req_id)
-    r = await _test_request(app, False, aps_data_error=True)
+    r = await _test_request(app, send_success=False, aps_data_error=True)
     assert r[0] != 0
+
+
+async def test_request_retry(app):
+    req_id = sentinel.req_id
+    app.get_sequence = MagicMock(return_value=req_id)
+
+    device = zigpy.device.Device(app, sentinel.ieee, 0x1122)
+    device.relays = [0x5678, 0x1234]
+    app.get_device = MagicMock(return_value=device)
+
+    async def req_mock(
+        req_id,
+        dst_addr_ep,
+        profile,
+        cluster,
+        src_ep,
+        data,
+        *,
+        relays=None,
+        tx_options=t.DeconzTransmitOptions.USE_NWK_KEY_SECURITY,
+        radius=0
+    ):
+        app._pending[req_id].result.set_result(1)
+
+    app._api.aps_data_request = MagicMock(side_effect=req_mock)
+    app._api.protocol_version = application.PROTO_VER_MANUAL_SOURCE_ROUTE
+
+    await app.request(device, 0x0260, 1, 2, 3, 123, b"\x01\x02\x03")
+
+    assert len(app._api.aps_data_request.mock_calls) == 2
+    without_relays, with_relays = app._api.aps_data_request.mock_calls
+
+    assert without_relays[2]["relays"] is None
+    assert with_relays[2]["relays"] == [0x0000, 0x1234, 0x5678]
 
 
 async def _test_broadcast(app, send_success=True, aps_data_error=False, **kwargs):

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -338,6 +338,7 @@ async def _test_request(app, send_success=True, aps_data_error=False, **kwargs):
             app._pending[req_id].result.set_result(1)
 
     app._api.aps_data_request = MagicMock(side_effect=req_mock)
+    app._api.protocol_version = 0
     device = zigpy.device.Device(app, sentinel.ieee, 0x1122)
     app.get_device = MagicMock(return_value=device)
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -277,3 +277,19 @@ def test_deconz_addr_ep():
         a.serialize()
     a.endpoint = 0xCC
     assert a.serialize() == data
+
+
+def test_nwklist():
+    assert t.NWKList([]).serialize() == b"\x00"
+    assert t.NWKList([0x1234]).serialize() == b"\x01" + t.NWK(0x1234).serialize()
+    assert (
+        t.NWKList([0x1234, 0x5678]).serialize()
+        == b"\x02" + t.NWK(0x1234).serialize() + t.NWK(0x5678).serialize()
+    )
+
+    assert t.NWKList.deserialize(b"\x00abc") == (t.NWKList([]), b"abc")
+    assert t.NWKList.deserialize(b"\x01\x34\x12abc") == (t.NWKList([0x1234]), b"abc")
+    assert t.NWKList.deserialize(b"\x02\x34\x12\x78\x56abc") == (
+        t.NWKList([0x1234, 0x5678]),
+        b"abc",
+    )

--- a/zigpy_deconz/api.py
+++ b/zigpy_deconz/api.py
@@ -533,7 +533,7 @@ class Deconz:
         delays = (0.5, 1.0, 1.5, None)
 
         flags = t.DeconzSendDataFlags.NONE
-        extra = []
+        extras = []
 
         # https://github.com/zigpy/zigpy-deconz/issues/180#issuecomment-1017932865
         if relays is not None:
@@ -544,10 +544,12 @@ class Deconz:
             assert len(relays) <= 9
 
             # APS ACKs should be used to mitigate errors.
-            flags |= t.DeconzSendDataFlags.USE_APS_ACKS
+            tx_options |= t.DeconzTransmitOptions.USE_APS_ACKS
 
             flags |= t.DeconzSendDataFlags.RELAYS
-            extra.append([t.uint16_t(nwk) for nwk in relays[::-1]])
+            extras.append(t.NWKList([t.uint16_t(nwk) for nwk in relays[::-1]]))
+
+        length += sum(len(e.serialize()) for e in extras)
 
         for delay in delays:
             try:
@@ -563,7 +565,7 @@ class Deconz:
                     aps_payload,
                     tx_options,
                     radius,
-                    *extra,
+                    *extras,
                 )
             except CommandError as ex:
                 LOGGER.debug("'aps_data_request' failure: %s", ex)

--- a/zigpy_deconz/api.py
+++ b/zigpy_deconz/api.py
@@ -536,7 +536,7 @@ class Deconz:
         extras = []
 
         # https://github.com/zigpy/zigpy-deconz/issues/180#issuecomment-1017932865
-        if relays is not None:
+        if relays:
             # There is a max of 9 relays
             assert len(relays) <= 9
 

--- a/zigpy_deconz/api.py
+++ b/zigpy_deconz/api.py
@@ -537,9 +537,6 @@ class Deconz:
 
         # https://github.com/zigpy/zigpy-deconz/issues/180#issuecomment-1017932865
         if relays is not None:
-            # The coordinator address 0x0000 must not be included in the relay list.
-            assert 0x0000 not in relays
-
             # There is a max of 9 relays
             assert len(relays) <= 9
 
@@ -547,7 +544,7 @@ class Deconz:
             tx_options |= t.DeconzTransmitOptions.USE_APS_ACKS
 
             flags |= t.DeconzSendDataFlags.RELAYS
-            extras.append(t.NWKList([t.uint16_t(nwk) for nwk in relays[::-1]]))
+            extras.append(t.NWKList(relays))
 
         length += sum(len(e.serialize()) for e in extras)
 

--- a/zigpy_deconz/types.py
+++ b/zigpy_deconz/types.py
@@ -126,6 +126,20 @@ class ADDRESS_MODE(uint8_t, enum.Enum):
     NWK_AND_IEEE = 0x04
 
 
+class DeconzSendDataFlags(uint8_t, enum.Enum):
+    NONE = 0x00
+    NODE_ID = 0x01
+    RELAYS = 0x02
+
+
+class DeconzTransmitOptions(uint8_t, enum.Enum):
+    NONE = 0x00
+    SECURITY_ENABLED = 0x01
+    USE_NWK_KEY_SECURITY = 0x02
+    USE_APS_ACKS = 0x04
+    ALLOW_FRAGMENTATION = 0x08
+
+
 class Struct:
     _fields = []
 
@@ -182,6 +196,25 @@ class List(list):
         return r, data
 
 
+class LVList(list):
+    _length_type = None
+    _itemtype = None
+
+    def serialize(self):
+        return self._length_type(len(self)).serialize() + b"".join(
+            [self._itemtype(i).serialize() for i in self]
+        )
+
+    @classmethod
+    def deserialize(cls, data):
+        length, data = cls._length_type.deserialize(data)
+        r = cls()
+        for _ in range(length):
+            item, data = cls._itemtype.deserialize(data)
+            r.append(item)
+        return r, data
+
+
 class FixedList(List):
     _length = None
     _itemtype = None
@@ -233,6 +266,11 @@ class PanId(HexRepr, uint16_t):
 
 class ExtendedPanId(EUI64):
     pass
+
+
+class NWKList(LVList):
+    _length_type = uint8_t
+    _itemtype = NWK
 
 
 class DeconzAddress(Struct):

--- a/zigpy_deconz/types.py
+++ b/zigpy_deconz/types.py
@@ -126,13 +126,36 @@ class ADDRESS_MODE(uint8_t, enum.Enum):
     NWK_AND_IEEE = 0x04
 
 
-class DeconzSendDataFlags(uint8_t, enum.Enum):
+def bitmap_factory(int_type: uint_t) -> enum.Flag:
+    class _NewEnum(int_type, enum.Flag):
+        # Rebind classmethods to our own class
+        _missing_ = classmethod(enum.IntFlag._missing_.__func__)
+        _create_pseudo_member_ = classmethod(
+            enum.IntFlag._create_pseudo_member_.__func__
+        )
+
+        __or__ = enum.IntFlag.__or__
+        __and__ = enum.IntFlag.__and__
+        __xor__ = enum.IntFlag.__xor__
+        __ror__ = enum.IntFlag.__ror__
+        __rand__ = enum.IntFlag.__rand__
+        __rxor__ = enum.IntFlag.__rxor__
+        __invert__ = enum.IntFlag.__invert__
+
+    return _NewEnum
+
+
+class bitmap8(bitmap_factory(uint8_t)):
+    pass
+
+
+class DeconzSendDataFlags(bitmap8):
     NONE = 0x00
     NODE_ID = 0x01
     RELAYS = 0x02
 
 
-class DeconzTransmitOptions(uint8_t, enum.Enum):
+class DeconzTransmitOptions(bitmap8):
     NONE = 0x00
     SECURITY_ENABLED = 0x01
     USE_NWK_KEY_SECURITY = 0x02

--- a/zigpy_deconz/zigbee/application.py
+++ b/zigpy_deconz/zigbee/application.py
@@ -26,6 +26,7 @@ LOGGER = logging.getLogger(__name__)
 CHANGE_NETWORK_WAIT = 1
 DELAY_NEIGHBOUR_SCAN_S = 1500
 SEND_CONFIRM_TIMEOUT = 60
+PROTO_VER_MANUAL_SOURCE_ROUTE = 0x010C
 PROTO_VER_WATCHDOG = 0x0108
 PROTO_VER_NEIGBOURS = 0x0107
 WATCHDOG_TTL = 600
@@ -284,7 +285,13 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         with self._pending.new(req_id) as req:
             try:
                 await self._api.aps_data_request(
-                    req_id, dst_addr_ep, profile, cluster, min(1, src_ep), data
+                    req_id,
+                    dst_addr_ep,
+                    profile,
+                    cluster,
+                    min(1, src_ep),
+                    data,
+                    relays=None,
                 )
             except zigpy_deconz.exception.CommandError as ex:
                 return ex.status, "Couldn't enqueue send data request: {}".format(ex)

--- a/zigpy_deconz/zigbee/application.py
+++ b/zigpy_deconz/zigbee/application.py
@@ -309,7 +309,9 @@ class ControllerApplication(zigpy.application.ControllerApplication):
                 if attempt == 2:
                     return r, "message send failure"
                 elif self._api.protocol_version >= PROTO_VER_MANUAL_SOURCE_ROUTE:
-                    relays = device.relays or []
+                    # Force the request to send by including the coordinator
+                    relays = [0x0000] + (device.relays or [])[::-1]
+
                     LOGGER.debug("Trying manual source route: %s", relays)
 
     async def broadcast(

--- a/zigpy_deconz/zigbee/application.py
+++ b/zigpy_deconz/zigbee/application.py
@@ -283,6 +283,10 @@ class ControllerApplication(zigpy.application.ControllerApplication):
             dst_addr_ep.address = device.nwk
 
         relays = None
+        tx_options = t.DeconzTransmitOptions.USE_NWK_KEY_SECURITY
+
+        if expect_reply:
+            tx_options |= t.DeconzTransmitOptions.USE_APS_ACKS
 
         for attempt in (1, 2):
             with self._pending.new(req_id) as req:
@@ -295,6 +299,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
                         min(1, src_ep),
                         data,
                         relays=relays,
+                        tx_options=tx_options,
                     )
                 except zigpy_deconz.exception.CommandError as ex:
                     return ex.status, f"Couldn't enqueue send data request: {ex}"

--- a/zigpy_deconz/zigbee/application.py
+++ b/zigpy_deconz/zigbee/application.py
@@ -311,7 +311,6 @@ class ControllerApplication(zigpy.application.ControllerApplication):
                 elif self._api.protocol_version >= PROTO_VER_MANUAL_SOURCE_ROUTE:
                     # Force the request to send by including the coordinator
                     relays = [0x0000] + (device.relays or [])[::-1]
-
                     LOGGER.debug("Trying manual source route: %s", relays)
 
     async def broadcast(


### PR DESCRIPTION
Maybe this can fix routing issues when the Conbee first starts up.

Fixes #180.