### PR TITLE
Fix isort

### DIFF
--- a/zigpy_deconz/config.py
+++ b/zigpy_deconz/config.py
@@ -2,19 +2,19 @@
 
 import voluptuous as vol
 from zigpy.config import (  # noqa: F401 pylint: disable=unused-import
-    CONF_NWK,
     CONF_DEVICE,
-    CONF_NWK_KEY,
-    CONFIG_SCHEMA,
-    SCHEMA_DEVICE,
-    CONF_NWK_PAN_ID,
     CONF_DEVICE_PATH,
+    CONF_NWK,
     CONF_NWK_CHANNEL,
     CONF_NWK_CHANNELS,
-    CONF_NWK_UPDATE_ID,
+    CONF_NWK_EXTENDED_PAN_ID,
+    CONF_NWK_KEY,
+    CONF_NWK_PAN_ID,
     CONF_NWK_TC_ADDRESS,
     CONF_NWK_TC_LINK_KEY,
-    CONF_NWK_EXTENDED_PAN_ID,
+    CONF_NWK_UPDATE_ID,
+    CONFIG_SCHEMA,
+    SCHEMA_DEVICE,
     cv_boolean,
 )
 


### PR DESCRIPTION
Somehow CI allowed https://github.com/zigpy/zigpy-deconz/pull/184 to be merged even though isort failed on `dev`.