### PR TITLE
Revert "Add support for tcp forwarded serial ports (#176)"

### DIFF
--- a/zigpy_deconz/uart.py
+++ b/zigpy_deconz/uart.py
@@ -4,7 +4,6 @@ import asyncio
 import binascii
 import logging
 from typing import Callable, Dict
-import urllib.parse
 
 import serial
 import serial_asyncio
@@ -140,21 +139,15 @@ async def connect(config: Dict[str, str], api: Callable, loop=None) -> Gateway:
     connected_future = asyncio.Future()
     protocol = Gateway(api, connected_future)
 
-    parsed_path = urllib.parse.urlparse(config[CONF_DEVICE_PATH])
-    if parsed_path.scheme == "tcp":
-        _, protocol = await loop.create_connection(
-            lambda: protocol, parsed_path.hostname, parsed_path.port
-        )
-    else:
-        _, protocol = await serial_asyncio.create_serial_connection(
-            loop,
-            lambda: protocol,
-            url=config[CONF_DEVICE_PATH],
-            baudrate=DECONZ_BAUDRATE,
-            parity=serial.PARITY_NONE,
-            stopbits=serial.STOPBITS_ONE,
-            xonxoff=False,
-        )
+    _, protocol = await serial_asyncio.create_serial_connection(
+        loop,
+        lambda: protocol,
+        url=config[CONF_DEVICE_PATH],
+        baudrate=DECONZ_BAUDRATE,
+        parity=serial.PARITY_NONE,
+        stopbits=serial.STOPBITS_ONE,
+        xonxoff=False,
+    )
 
     await connected_future
 


### PR DESCRIPTION
This reverts commit 22f07a4cce0f256b49b077827c6a9b26bc586250.

Interestingly, that PR sort of fixed https://github.com/pyserial/pyserial-asyncio/issues/81 by avoiding pyserial entirely.  If pyserial-asyncio won't fix this problem, we may have to implement a pyserial-asyncio connection wrapper like this in zigpy for use in all other radio libraries.