### PR TITLE
Implement request concurrency limits

### DIFF
--- a/zigpy_deconz/config.py
+++ b/zigpy_deconz/config.py
@@ -21,7 +21,7 @@ from zigpy.config import (  # noqa: F401 pylint: disable=unused-import
 CONF_DECONZ_CONFIG = "deconz_config"
 
 CONF_MAX_CONCURRENT_REQUESTS = "max_concurrent_requests"
-CONF_MAX_CONCURRENT_REQUESTS_DEFAULT = 16
+CONF_MAX_CONCURRENT_REQUESTS_DEFAULT = 8
 
 CONF_WATCHDOG_TTL = "watchdog_ttl"
 CONF_WATCHDOG_TTL_DEFAULT = 600

--- a/zigpy_deconz/config.py
+++ b/zigpy_deconz/config.py
@@ -18,6 +18,11 @@ from zigpy.config import (  # noqa: F401 pylint: disable=unused-import
     cv_boolean,
 )
 
+CONF_DECONZ_CONFIG = "deconz_config"
+
+CONF_MAX_CONCURRENT_REQUESTS = "max_concurrent_requests"
+CONF_MAX_CONCURRENT_REQUESTS_DEFAULT = 16
+
 CONF_WATCHDOG_TTL = "watchdog_ttl"
 CONF_WATCHDOG_TTL_DEFAULT = 600
 
@@ -25,6 +30,14 @@ CONFIG_SCHEMA = CONFIG_SCHEMA.extend(
     {
         vol.Optional(CONF_WATCHDOG_TTL, default=CONF_WATCHDOG_TTL_DEFAULT): vol.All(
             int, vol.Range(min=180)
-        )
+        ),
+        vol.Optional(CONF_DECONZ_CONFIG, default={}): vol.Schema(
+            {
+                vol.Optional(
+                    CONF_MAX_CONCURRENT_REQUESTS,
+                    default=CONF_MAX_CONCURRENT_REQUESTS_DEFAULT,
+                ): vol.All(int, vol.Range(min=1))
+            }
+        ),
     }
 )

--- a/zigpy_deconz/zigbee/application.py
+++ b/zigpy_deconz/zigbee/application.py
@@ -2,8 +2,10 @@
 
 import asyncio
 import binascii
+import contextlib
 import logging
 import re
+import time
 from typing import Any, Dict
 
 import zigpy.application
@@ -18,7 +20,13 @@ import zigpy.util
 
 from zigpy_deconz import types as t
 from zigpy_deconz.api import Deconz, NetworkParameter, NetworkState, Status
-from zigpy_deconz.config import CONF_WATCHDOG_TTL, CONFIG_SCHEMA, SCHEMA_DEVICE
+from zigpy_deconz.config import (
+    CONF_DECONZ_CONFIG,
+    CONF_MAX_CONCURRENT_REQUESTS,
+    CONF_WATCHDOG_TTL,
+    CONFIG_SCHEMA,
+    SCHEMA_DEVICE,
+)
 import zigpy_deconz.exception
 
 LOGGER = logging.getLogger(__name__)
@@ -43,7 +51,13 @@ class ControllerApplication(zigpy.application.ControllerApplication):
 
         super().__init__(config=zigpy.config.ZIGPY_SCHEMA(config))
         self._api = None
+
         self._pending = zigpy.util.Requests()
+        self._concurrent_requests_semaphore = asyncio.Semaphore(
+            self._config[CONF_DECONZ_CONFIG][CONF_MAX_CONCURRENT_REQUESTS]
+        )
+        self._currently_waiting_requests = 0
+
         self._nwk = 0
         self.version = 0
 
@@ -199,6 +213,38 @@ class ControllerApplication(zigpy.application.ControllerApplication):
             await asyncio.sleep(CHANGE_NETWORK_WAIT)
         raise Exception("Could not form network.")
 
+    @contextlib.asynccontextmanager
+    async def _limit_concurrency(self):
+        """Async context manager to prevent devices from being overwhelmed by requests.
+
+        Mainly a thin wrapper around `asyncio.Semaphore` that logs when it has to wait.
+        """
+
+        start_time = time.time()
+        was_locked = self._concurrent_requests_semaphore.locked()
+
+        if was_locked:
+            self._currently_waiting_requests += 1
+            LOGGER.debug(
+                "Max concurrency (%s) reached, delaying requests (%s enqueued)",
+                self._config[CONF_DECONZ_CONFIG][CONF_MAX_CONCURRENT_REQUESTS],
+                self._currently_waiting_requests,
+            )
+
+        try:
+            async with self._concurrent_requests_semaphore:
+                if was_locked:
+                    LOGGER.debug(
+                        "Previously delayed request is now running, "
+                        "delayed by %0.2f seconds",
+                        time.time() - start_time,
+                    )
+
+                yield
+        finally:
+            if was_locked:
+                self._currently_waiting_requests -= 1
+
     async def mrequest(
         self,
         group_id,
@@ -238,20 +284,21 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         dst_addr_ep.address_mode = t.ADDRESS_MODE.GROUP
         dst_addr_ep.address = group_id
 
-        with self._pending.new(req_id) as req:
-            try:
-                await self._api.aps_data_request(
-                    req_id, dst_addr_ep, profile, cluster, min(1, src_ep), data
-                )
-            except zigpy_deconz.exception.CommandError as ex:
-                return ex.status, "Couldn't enqueue send data request: {}".format(ex)
+        async with self._limit_concurrency():
+            with self._pending.new(req_id) as req:
+                try:
+                    await self._api.aps_data_request(
+                        req_id, dst_addr_ep, profile, cluster, min(1, src_ep), data
+                    )
+                except zigpy_deconz.exception.CommandError as ex:
+                    return ex.status, f"Couldn't enqueue send data request: {ex!r}"
 
-            r = await asyncio.wait_for(req.result, SEND_CONFIRM_TIMEOUT)
-            if r:
-                LOGGER.debug("Error while sending %s req id frame: %s", req_id, r)
-                return r, "message send failure"
+                r = await asyncio.wait_for(req.result, SEND_CONFIRM_TIMEOUT)
+                if r:
+                    LOGGER.debug("Error while sending %s req id frame: %s", req_id, r)
+                    return r, f"message send failure: {r}"
 
-        return Status.SUCCESS, "message send success"
+            return Status.SUCCESS, "message send success"
 
     @zigpy.util.retryable_request
     async def request(
@@ -289,34 +336,35 @@ class ControllerApplication(zigpy.application.ControllerApplication):
             tx_options |= t.DeconzTransmitOptions.USE_APS_ACKS
 
         for attempt in (1, 2):
-            with self._pending.new(req_id) as req:
-                try:
-                    await self._api.aps_data_request(
-                        req_id,
-                        dst_addr_ep,
-                        profile,
-                        cluster,
-                        min(1, src_ep),
-                        data,
-                        relays=relays,
-                        tx_options=tx_options,
-                    )
-                except zigpy_deconz.exception.CommandError as ex:
-                    return ex.status, f"Couldn't enqueue send data request: {ex}"
+            async with self._limit_concurrency():
+                with self._pending.new(req_id) as req:
+                    try:
+                        await self._api.aps_data_request(
+                            req_id,
+                            dst_addr_ep,
+                            profile,
+                            cluster,
+                            min(1, src_ep),
+                            data,
+                            relays=relays,
+                            tx_options=tx_options,
+                        )
+                    except zigpy_deconz.exception.CommandError as ex:
+                        return ex.status, f"Couldn't enqueue send data request: {ex}"
 
-                r = await asyncio.wait_for(req.result, SEND_CONFIRM_TIMEOUT)
+                    r = await asyncio.wait_for(req.result, SEND_CONFIRM_TIMEOUT)
 
-                if not r:
-                    return r, "message send success"
+                    if not r:
+                        return r, "message send success"
 
-                LOGGER.debug("Error while sending %s req id frame: %s", req_id, r)
+                    LOGGER.debug("Error while sending %s req id frame: %s", req_id, r)
 
-                if attempt == 2:
-                    return r, "message send failure"
-                elif self._api.protocol_version >= PROTO_VER_MANUAL_SOURCE_ROUTE:
-                    # Force the request to send by including the coordinator
-                    relays = [0x0000] + (device.relays or [])[::-1]
-                    LOGGER.debug("Trying manual source route: %s", relays)
+                    if attempt == 2:
+                        return r, f"message send failure: {r}"
+                    elif self._api.protocol_version >= PROTO_VER_MANUAL_SOURCE_ROUTE:
+                        # Force the request to send by including the coordinator
+                        relays = [0x0000] + (device.relays or [])[::-1]
+                        LOGGER.debug("Trying manual source route: %s", relays)
 
     async def broadcast(
         self,
@@ -342,23 +390,26 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         dst_addr_ep.address = t.uint16_t(broadcast_address)
         dst_addr_ep.endpoint = dst_ep
 
-        with self._pending.new(req_id) as req:
-            try:
-                await self._api.aps_data_request(
-                    req_id, dst_addr_ep, profile, cluster, min(1, src_ep), data
-                )
-            except zigpy_deconz.exception.CommandError as ex:
-                return (
-                    ex.status,
-                    "Couldn't enqueue send data request for broadcast: {}".format(ex),
-                )
+        async with self._limit_concurrency():
+            with self._pending.new(req_id) as req:
+                try:
+                    await self._api.aps_data_request(
+                        req_id, dst_addr_ep, profile, cluster, min(1, src_ep), data
+                    )
+                except zigpy_deconz.exception.CommandError as ex:
+                    return (
+                        ex.status,
+                        f"Couldn't enqueue send data request for broadcast: {ex!r}",
+                    )
 
-            r = await asyncio.wait_for(req.result, SEND_CONFIRM_TIMEOUT)
+                r = await asyncio.wait_for(req.result, SEND_CONFIRM_TIMEOUT)
 
-            if r:
-                LOGGER.debug("Error while sending %s req id broadcast: %s", req_id, r)
-                return r, "broadcast send failure"
-            return r, "broadcast send success"
+                if r:
+                    LOGGER.debug(
+                        "Error while sending %s req id broadcast: %s", req_id, r
+                    )
+                    return r, f"broadcast send failure: {r}"
+                return r, "broadcast send success"
 
     async def permit_ncp(self, time_s=60):
         assert 0 <= time_s <= 254

--- a/zigpy_deconz/zigbee/application.py
+++ b/zigpy_deconz/zigbee/application.py
@@ -4,6 +4,7 @@ import asyncio
 import binascii
 import contextlib
 import logging
+import random
 import re
 import time
 from typing import Any, Dict
@@ -38,6 +39,8 @@ PROTO_VER_MANUAL_SOURCE_ROUTE = 0x010C
 PROTO_VER_WATCHDOG = 0x0108
 PROTO_VER_NEIGBOURS = 0x0107
 WATCHDOG_TTL = 600
+
+MAX_REQUEST_RETRY_DELAY = 1.0
 
 
 class ControllerApplication(zigpy.application.ControllerApplication):
@@ -358,6 +361,8 @@ class ControllerApplication(zigpy.application.ControllerApplication):
                         return r, "message send success"
 
                     LOGGER.debug("Error while sending %s req id frame: %s", req_id, r)
+
+                    await asyncio.sleep(random.uniform(0, MAX_REQUEST_RETRY_DELAY))
 
                     if attempt == 2:
                         return r, f"message send failure: {r}"


### PR DESCRIPTION
This implementation is mostly copied from zigpy-znp.

8 seems to be the limit that keeps `BUSY` statuses out of logs during ZHA startup when all ZHA semaphores are removed.

~~I've also added a random (up to one second) delay between the two request retries, hopefully to break up groups of failing requests that were sent concurrently.~~