### PR TITLE
Allowing up to 4 Endpoints

### DIFF
--- a/zigpy_deconz/zigbee/application.py
+++ b/zigpy_deconz/zigbee/application.py
@@ -49,7 +49,7 @@ PROTO_VER_MANUAL_SOURCE_ROUTE = 0x010C
 PROTO_VER_WATCHDOG = 0x0108
 PROTO_VER_NEIGBOURS = 0x0107
 WATCHDOG_TTL = 600
-MAX_NUM_ENDPOINTS = 2  # defined in firmware
+MAX_NUM_ENDPOINTS = 4  # defined in firmware
 
 
 class ControllerApplication(zigpy.application.ControllerApplication):


### PR DESCRIPTION
As documented https://github.com/zigbeefordomoticz/Domoticz-Zigbee/issues/1145 the new firmware will provide a 4 Endpoint slots instead of 2.