### PR TITLE
Update URLs in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,12 @@
 
 [zigpy-deconz](https://github.com/zigpy/zigpy-deconz) is a Python 3 implementation for the [Zigpy](https://github.com/zigpy/) project to implement [deCONZ](https://www.dresden-elektronik.de/funktechnik/products/software/pc/deconz/) based [Zigbee](https://www.zigbee.org) radio devices.
 
-The goal of this project to add native support for the Dresden-Elektronik deCONZ based ZigBee modules in Home Assistant via [Zigpy](https://github.com/zigpy/).
+The goal of this project to add native support for the Dresden-Elektronik/Phoscon deCONZ based ZigBee modules in Home Assistant via [zigpy](https://github.com/zigpy/).
 
-This library uses the deCONZ serial protocol for communicating with [ConBee](https://www.dresden-elektronik.de/conbee/), [ConBee II (ConBee 2)](https://shop.dresden-elektronik.de/conbee-2.html), and [RaspBee](https://www.dresden-elektronik.de/raspbee/) adapters from [Dresden-Elektronik](https://github.com/dresden-elektronik/).
+This library uses the deCONZ serial protocol for communicating with [ConBee](https://phoscon.de/en/conbee), [ConBee II (ConBee 2)](https://phoscon.de/en/conbee2), [RaspBee](https://phoscon.de/en/raspbee), and [RaspBee II (RaspBee 2)](https://phoscon.de/en/raspbee2) adapters from [Dresden-Elektronik](https://github.com/dresden-elektronik/)/[Phoscon](https://phoscon.de).
 
 # Releases via PyPI
+
 Tagged versions are also released via PyPI
 
 - https://pypi.org/project/zigpy-deconz/
@@ -18,10 +19,13 @@ Tagged versions are also released via PyPI
 
 # External documentation and reference
 
-Note! Latest official documentation for the deCONZ serial protocol can currently be obtained by contacting Dresden-Elektronik employees via GitHub here
--  https://github.com/dresden-elektronik/deconz-rest-plugin/issues/158
+Note! Latest official documentation for the deCONZ serial protocol can currently be obtained by following link in Dresden-Elektronik GitHub repository here:
 
-For reference, here is a list of unrelated projects that also use the same deCONZ serial protocol for other implementations
+- https://github.com/dresden-elektronik/deconz-serial-protocol
+- https://github.com/dresden-elektronik/deconz-serial-protocol/issues/2
+
+For reference, here is a list of unrelated projects that also use the same deCONZ serial protocol for other implementations:
+
 - https://github.com/Equidamoid/pyconz/commits/master
 - https://github.com/mozilla-iot/deconz-api
 - https://github.com/adetante/deconz-sp
@@ -30,6 +34,7 @@ For reference, here is a list of unrelated projects that also use the same deCON
 # How to contribute
 
 If you are looking to make a contribution to this project we suggest that you follow the steps in these guides:
+
 - https://github.com/firstcontributions/first-contributions/blob/master/README.md
 - https://github.com/firstcontributions/first-contributions/blob/master/github-desktop-tutorial.md
 


### PR DESCRIPTION
Update URLs in README.md and mention/link to RaspBee II (RaspBee 2) Zigbee Coordinator.

Also update URL to upstream deCONZ Serial Protocol for documentation and issue reporting.