### PR TITLE
Move reconnect logic into `ControllerApplication`

### DIFF
--- a/tests/test_uart.py
+++ b/tests/test_uart.py
@@ -122,4 +122,4 @@ def test_connection_lost_exc(gw):
 def test_connection_closed(gw):
     gw.connection_lost(None)
 
-    assert gw._api.connection_lost.call_count == 0
+    assert gw._api.connection_lost.call_count == 1

--- a/zigpy_deconz/api.py
+++ b/zigpy_deconz/api.py
@@ -242,7 +242,6 @@ class Deconz:
         self._awaiting = {}
         self._command_lock = asyncio.Lock()
         self._config = device_config
-        self._conn_lost_task: Optional[asyncio.Task] = None
         self._data_indication: bool = False
         self._data_confirm: bool = False
         self._device_state = DeviceState(NetworkState.OFFLINE)
@@ -277,13 +276,16 @@ class Deconz:
             self._config[CONF_DEVICE_PATH],
             exc,
         )
-        self._uart.close()
-        self._uart = None
 
-        self._app.connection_lost(exc)
+        if self._uart is not None:
+            self._uart.close()
+            self._uart = None
+
+        if self._app is not None:
+            self._app.connection_lost(exc)
 
     def close(self):
-        if self._uart:
+        if self._uart is not None:
             self._uart.close()
             self._uart = None
 

--- a/zigpy_deconz/uart.py
+++ b/zigpy_deconz/uart.py
@@ -32,16 +32,15 @@ class Gateway(asyncio.Protocol):
     def connection_lost(self, exc) -> None:
         """Port was closed expectedly or unexpectedly."""
 
+        if exc is not None:
+            LOGGER.error("Lost serial connection: %s", exc)
+
         if self._connected_future and not self._connected_future.done():
             if exc is None:
                 self._connected_future.set_result(True)
             else:
                 self._connected_future.set_exception(exc)
-        if exc is None:
-            LOGGER.debug("Closed serial connection")
-            return
 
-        LOGGER.error("Lost serial connection: %s", exc)
         self._api.connection_lost(exc)
 
     def connection_made(self, transport):
@@ -49,7 +48,7 @@ class Gateway(asyncio.Protocol):
 
         LOGGER.debug("Connection made")
         self._transport = transport
-        if self._connected_future:
+        if self._connected_future and not self._connected_future.done():
             self._connected_future.set_result(True)
 
     def close(self):
@@ -132,16 +131,16 @@ class Gateway(asyncio.Protocol):
         return bytes(ret)
 
 
-async def connect(config: Dict[str, str], api: Callable, loop=None) -> Gateway:
-    if loop is None:
-        loop = asyncio.get_event_loop()
-
-    connected_future = asyncio.Future()
+async def connect(config: Dict[str, str], api: Callable) -> Gateway:
+    loop = asyncio.get_running_loop()
+    connected_future = loop.create_future()
     protocol = Gateway(api, connected_future)
 
+    LOGGER.debug("Connecting to %s", config[CONF_DEVICE_PATH])
+
     _, protocol = await serial_asyncio.create_serial_connection(
-        loop,
-        lambda: protocol,
+        loop=loop,
+        protocol_factory=lambda: protocol,
         url=config[CONF_DEVICE_PATH],
         baudrate=DECONZ_BAUDRATE,
         parity=serial.PARITY_NONE,
@@ -150,5 +149,7 @@ async def connect(config: Dict[str, str], api: Callable, loop=None) -> Gateway:
     )
 
     await connected_future
+
+    LOGGER.debug("Connected to to %s", config[CONF_DEVICE_PATH])
 
     return protocol

--- a/zigpy_deconz/zigbee/application.py
+++ b/zigpy_deconz/zigbee/application.py
@@ -82,6 +82,8 @@ class ControllerApplication(zigpy.application.ControllerApplication):
                 )
             except Exception as e:
                 LOGGER.warning("Failed to reset watchdog", exc_info=e)
+                self.connection_lost(e)
+                return
 
             await asyncio.sleep(self._config[CONF_WATCHDOG_TTL] * 0.75)
 

--- a/zigpy_deconz/zigbee/application.py
+++ b/zigpy_deconz/zigbee/application.py
@@ -45,10 +45,10 @@ LOGGER = logging.getLogger(__name__)
 CHANGE_NETWORK_WAIT = 1
 DELAY_NEIGHBOUR_SCAN_S = 1500
 SEND_CONFIRM_TIMEOUT = 60
+
 PROTO_VER_MANUAL_SOURCE_ROUTE = 0x010C
 PROTO_VER_WATCHDOG = 0x0108
 PROTO_VER_NEIGBOURS = 0x0107
-WATCHDOG_TTL = 600
 
 
 class ControllerApplication(zigpy.application.ControllerApplication):
@@ -67,7 +67,6 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         )
         self._currently_waiting_requests = 0
 
-        self._nwk = 0
         self.version = 0
         self._reset_watchdog_task = None
         self._reconnect_task = None


### PR DESCRIPTION
Reconnecting within the lower-level API had the unintentional side effect of causing reconnects if probing fails. This brings zigpy-deconz in line with the other radio libraries.

In the future this will be handled by zigpy, since the code across all the libraries is nearly identical.