### PR TITLE
Do not close the UART within `api.Deconz`

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -593,10 +593,8 @@ async def test_aps_data_request_relays(relays, api):
 
 async def test_connection_lost(api):
     app = api._app = MagicMock()
-    uart = api._uart = MagicMock()
 
     err = RuntimeError()
     api.connection_lost(err)
 
     app.connection_lost.assert_called_once_with(err)
-    uart.close.assert_called_once()

--- a/zigpy_deconz/api.py
+++ b/zigpy_deconz/api.py
@@ -271,20 +271,18 @@ class Deconz:
 
     def connection_lost(self, exc: Exception) -> None:
         """Lost serial connection."""
-        LOGGER.warning(
+        LOGGER.debug(
             "Serial '%s' connection lost unexpectedly: %s",
             self._config[CONF_DEVICE_PATH],
             exc,
         )
 
-        if self._uart is not None:
-            self._uart.close()
-            self._uart = None
-
         if self._app is not None:
             self._app.connection_lost(exc)
 
     def close(self):
+        self._app = None
+
         if self._uart is not None:
             self._uart.close()
             self._uart = None

--- a/zigpy_deconz/zigbee/application.py
+++ b/zigpy_deconz/zigbee/application.py
@@ -659,7 +659,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
     def connection_lost(self, exc: Exception) -> None:
         """Lost connection."""
 
-        LOGGER.warning("Lost connection: %r", exc)
+        LOGGER.debug("Lost connection: %r", exc)
 
         self.close()
         self._reconnect_task = asyncio.create_task(self._reconnect_loop())


### PR DESCRIPTION
#202 did not fix the bug where zigpy-deconz attempted to reconnect after a failed probe.