### PR TITLE
Ensure the serial port is closed when there is a connection failure

### DIFF
--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -180,6 +180,23 @@ async def test_connect(app):
         assert app.version is sentinel.version
 
 
+async def test_connect_failure(app):
+    with patch.object(application, "Deconz") as api_mock:
+        api = api_mock.return_value = MagicMock()
+        api.connect = AsyncMock()
+        api.version = AsyncMock(side_effect=RuntimeError("Broken"))
+
+        app._api = None
+
+        with pytest.raises(RuntimeError):
+            await app.connect()
+
+        assert app._api is None
+        api.connect.assert_called_once()
+        api.version.assert_called_once()
+        api.close.assert_called_once()
+
+
 async def test_disconnect(app):
     reset_watchdog_task = app._reset_watchdog_task = MagicMock()
     api_close = app._api.close = MagicMock()

--- a/zigpy_deconz/zigbee/application.py
+++ b/zigpy_deconz/zigbee/application.py
@@ -76,8 +76,14 @@ class ControllerApplication(zigpy.application.ControllerApplication):
 
     async def connect(self):
         api = Deconz(self, self._config[zigpy.config.CONF_DEVICE])
-        await api.connect()
-        self.version = await api.version()
+
+        try:
+            await api.connect()
+            self.version = await api.version()
+        except Exception:
+            api.close()
+            raise
+
         self._api = api
         self._written_endpoints.clear()
 


### PR DESCRIPTION
This bug causes all sorts of double-connect problems when zigpy-deconz has been used to probe and is perpetually trying to reconnect in the background.
