### PR TITLE
Fail with a descriptive error message if startup loops endlessly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,7 +271,7 @@ jobs:
     needs: prepare-base
     strategy:
       matrix:
-        python-version: ['3.8.14', '3.9.15', '3.10.8', '3.11.0']
+        python-version: ['3.8.16', '3.9.15', '3.10.8', '3.11.0']
     name: >-
       Run tests Python ${{ matrix.python-version }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,7 +311,7 @@ jobs:
           . venv/bin/activate
           pytest \
             -qq \
-            --timeout=9 \
+            --timeout=15 \
             --durations=10 \
             --cov zigpy_deconz \
             --cov-report=term-missing \

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -112,28 +112,32 @@ def addr_nwk_and_ieee(nwk, ieee):
     return addr
 
 
+@patch("zigpy_deconz.zigbee.application.CHANGE_NETWORK_WAIT", 0.001)
 @pytest.mark.parametrize(
-    "proto_ver, nwk_state, error",
+    "proto_ver, target_state, returned_state",
     [
-        (0x0107, deconz_api.NetworkState.CONNECTED, None),
-        (0x0106, deconz_api.NetworkState.CONNECTED, None),
-        (0x0107, deconz_api.NetworkState.OFFLINE, None),
-        (0x0107, deconz_api.NetworkState.OFFLINE, asyncio.TimeoutError()),
+        (0x0107, deconz_api.NetworkState.CONNECTED, deconz_api.NetworkState.CONNECTED),
+        (0x0106, deconz_api.NetworkState.CONNECTED, deconz_api.NetworkState.CONNECTED),
+        (0x0107, deconz_api.NetworkState.OFFLINE, deconz_api.NetworkState.CONNECTED),
+        (0x0107, deconz_api.NetworkState.CONNECTED, deconz_api.NetworkState.OFFLINE),
     ],
 )
-async def test_start_network(app, proto_ver, nwk_state, error):
+async def test_start_network(app, proto_ver, target_state, returned_state):
     app.load_network_info = AsyncMock()
     app.restore_neighbours = AsyncMock()
     app.add_endpoint = AsyncMock()
-    app._change_network_state = AsyncMock(side_effect=error)
 
     app._api.device_state = AsyncMock(
-        return_value=(deconz_api.DeviceState(nwk_state), 0, 0)
+        return_value=(deconz_api.DeviceState(returned_state), 0, 0)
     )
+
     app._api._proto_ver = proto_ver
     app._api.protocol_version = proto_ver
 
-    if nwk_state != deconz_api.NetworkState.CONNECTED and error is not None:
+    if (
+        target_state == deconz_api.NetworkState.CONNECTED
+        and returned_state != deconz_api.NetworkState.CONNECTED
+    ):
         with pytest.raises(zigpy.exceptions.FormationFailure):
             await app.start_network()
 

--- a/zigpy_deconz/zigbee/application.py
+++ b/zigpy_deconz/zigbee/application.py
@@ -111,11 +111,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
     async def start_network(self):
         await self.register_endpoints()
         await self.load_network_info(load_devices=False)
-
-        try:
-            await self._change_network_state(NetworkState.CONNECTED)
-        except asyncio.TimeoutError as e:
-            raise FormationFailure() from e
+        await self._change_network_state(NetworkState.CONNECTED)
 
         coordinator = await DeconzDevice.new(
             self,
@@ -141,7 +137,19 @@ class ControllerApplication(zigpy.application.ControllerApplication):
                 await asyncio.sleep(CHANGE_NETWORK_WAIT)
 
         await self._api.change_network_state(target_state)
-        await asyncio.wait_for(change_loop(), timeout=timeout)
+
+        try:
+            await asyncio.wait_for(change_loop(), timeout=timeout)
+        except asyncio.TimeoutError:
+            if target_state != NetworkState.CONNECTED:
+                raise
+
+            raise FormationFailure(
+                "Network formation refused: there is likely too much RF interference."
+                " Make sure your coordinator is on a USB 2.0 extension cable and"
+                " away from any sources of interference, like USB 3.0 ports, SSDs,"
+                " 2.4GHz routers, motherboards, etc."
+            )
 
         if self._api.protocol_version < PROTO_VER_WATCHDOG:
             return


### PR DESCRIPTION
This is caused by RF interference, as the Conbee's startup scan fails.