### PR TITLE
Conbee III support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ license = {text = "GPL-3.0"}
 requires-python = ">=3.8"
 dependencies = [
     "voluptuous",
-    "zigpy>=0.54.1",
+    "zigpy>=0.60.0",
     'async-timeout; python_version<"3.11"',
 ]
 

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -608,7 +608,7 @@ async def test_energy_scan_conbee_3(app):
     type(app)._device = AsyncMock()
 
     app._device.zdo.Mgmt_NWK_Update_req = AsyncMock(
-        side_effect=zigpy.exceptions.DeliveryError()
+        side_effect=zigpy.exceptions.DeliveryError("error")
     )
 
     with pytest.raises(zigpy.exceptions.DeliveryError):

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -248,9 +248,7 @@ async def test_deconz_dev_add_to_group(app, nwk, device_path):
     app._groups = MagicMock()
     app._groups.add_group.return_value = group
 
-    deconz = application.DeconzDevice(
-        deconz_api.FirmwareVersion(0x26580700), device_path, app, sentinel.ieee, nwk
-    )
+    deconz = application.DeconzDevice("Conbee II", app, sentinel.ieee, nwk)
     deconz.endpoints = {
         0: sentinel.zdo,
         1: sentinel.ep1,
@@ -268,9 +266,7 @@ async def test_deconz_dev_add_to_group(app, nwk, device_path):
 async def test_deconz_dev_remove_from_group(app, nwk, device_path):
     group = MagicMock()
     app.groups[sentinel.grp_id] = group
-    deconz = application.DeconzDevice(
-        deconz_api.FirmwareVersion(0x26580700), device_path, app, sentinel.ieee, nwk
-    )
+    deconz = application.DeconzDevice("Conbee II", app, sentinel.ieee, nwk)
     deconz.endpoints = {
         0: sentinel.zdo,
         1: sentinel.ep1,
@@ -282,38 +278,16 @@ async def test_deconz_dev_remove_from_group(app, nwk, device_path):
 
 
 def test_deconz_props(nwk, device_path):
-    deconz = application.DeconzDevice(
-        deconz_api.FirmwareVersion(0x26580700), device_path, app, sentinel.ieee, nwk
-    )
+    deconz = application.DeconzDevice("Conbee II", app, sentinel.ieee, nwk)
     assert deconz.manufacturer is not None
     assert deconz.model is not None
-
-
-@pytest.mark.parametrize(
-    "name, firmware_version, device_path",
-    [
-        ("ConBee", deconz_api.FirmwareVersion(0x00000500), "/dev/ttyUSB0"),
-        ("ConBee II", deconz_api.FirmwareVersion(0x00000700), "/dev/ttyUSB0"),
-        ("RaspBee", deconz_api.FirmwareVersion(0x00000500), "/dev/ttyS0"),
-        ("RaspBee II", deconz_api.FirmwareVersion(0x00000700), "/dev/ttyS0"),
-        ("RaspBee", deconz_api.FirmwareVersion(0x00000500), "/dev/ttyAMA0"),
-        ("RaspBee II", deconz_api.FirmwareVersion(0x00000700), "/dev/ttyAMA0"),
-    ],
-)
-def test_deconz_name(nwk, name, firmware_version, device_path):
-    deconz = application.DeconzDevice(
-        firmware_version, device_path, app, sentinel.ieee, nwk
-    )
-    assert deconz.model == name
 
 
 async def test_deconz_new(app, nwk, device_path, monkeypatch):
     mock_init = AsyncMock()
     monkeypatch.setattr(zigpy.device.Device, "_initialize", mock_init)
 
-    deconz = await application.DeconzDevice.new(
-        app, sentinel.ieee, nwk, deconz_api.FirmwareVersion(0x26580700), device_path
-    )
+    deconz = await application.DeconzDevice.new(app, sentinel.ieee, nwk, "Conbee II")
     assert isinstance(deconz, application.DeconzDevice)
     assert mock_init.call_count == 1
     mock_init.reset_mock()
@@ -325,9 +299,7 @@ async def test_deconz_new(app, nwk, device_path, monkeypatch):
         22: MagicMock(),
     }
     app.devices[sentinel.ieee] = mock_dev
-    deconz = await application.DeconzDevice.new(
-        app, sentinel.ieee, nwk, deconz_api.FirmwareVersion(0x26580700), device_path
-    )
+    deconz = await application.DeconzDevice.new(app, sentinel.ieee, nwk, "Conbee II")
     assert isinstance(deconz, application.DeconzDevice)
     assert mock_init.call_count == 0
 

--- a/tests/test_network_state.py
+++ b/tests/test_network_state.py
@@ -60,11 +60,12 @@ def network_info(node_info):
         nwk_addresses={},
         stack_specific={},
         source=f"zigpy-deconz@{importlib.metadata.version('zigpy-deconz')}",
-        metadata={"deconz": {"version": "0x00000001"}},
+        metadata={"deconz": {"version": "0x26580700"}},
     )
 
 
-@patch.object(application, "CHANGE_NETWORK_WAIT", 0.001)
+@patch.object(application, "CHANGE_NETWORK_POLL_TIME", 0.001)
+@patch.object(application, "CHANGE_NETWORK_STATE_DELAY", 0.001)
 @pytest.mark.parametrize(
     "channel_mask, channel, security_level, fw_supports_fc, logical_type",
     [
@@ -182,7 +183,8 @@ async def test_write_network_info(
         assert params["security_mode"] == (zigpy_deconz.api.SecurityMode.ONLY_TCLK,)
 
 
-@patch.object(application, "CHANGE_NETWORK_WAIT", 0.001)
+@patch.object(application, "CHANGE_NETWORK_POLL_TIME", 0.001)
+@patch.object(application, "CHANGE_NETWORK_STATE_DELAY", 0.001)
 @pytest.mark.parametrize(
     "error, param_overrides, nwk_state_changes, node_state_changes",
     [

--- a/tests/test_network_state.py
+++ b/tests/test_network_state.py
@@ -32,6 +32,9 @@ def node_info():
         nwk=t.NWK(0x0000),
         ieee=t.EUI64.convert("93:2C:A9:34:D9:D0:5D:12"),
         logical_type=zdo_t.LogicalType.Coordinator,
+        manufacturer="dresden elektronik",
+        model="Conbee II",
+        version="0x26580700",
     )
 
 
@@ -263,6 +266,7 @@ async def test_load_network_info(
             ieee=node_info.ieee, key=network_info.tc_link_key.key
         ),
         ("security_mode",): zigpy_deconz.api.SecurityMode.ONLY_TCLK,
+        ("protocol_version",): 0x010E,
     }
 
     params.update(param_overrides)
@@ -280,6 +284,7 @@ async def test_load_network_info(
 
         return value
 
+    app._api.firmware_version = zigpy_deconz.api.FirmwareVersion(0x26580700)
     app._api.read_parameter = AsyncMock(side_effect=read_param)
 
     if error is not None:

--- a/tests/test_uart.py
+++ b/tests/test_uart.py
@@ -4,11 +4,10 @@ import logging
 from unittest import mock
 
 import pytest
-from zigpy.config import CONF_DEVICE_PATH
+from zigpy.config import CONF_DEVICE_BAUDRATE, CONF_DEVICE_PATH
 import zigpy.serial
 
 from zigpy_deconz import uart
-from zigpy_deconz.config import CONF_DEVICE_BAUDRATE
 
 
 @pytest.fixture

--- a/zigpy_deconz/config.py
+++ b/zigpy_deconz/config.py
@@ -23,21 +23,8 @@ CONF_DECONZ_CONFIG = "deconz_config"
 
 CONF_MAX_CONCURRENT_REQUESTS_DEFAULT = 8
 
-CONF_WATCHDOG_TTL = "watchdog_ttl"
-CONF_WATCHDOG_TTL_DEFAULT = 600
-
-CONF_DEVICE_BAUDRATE = "baudrate"
-
-SCHEMA_DEVICE = SCHEMA_DEVICE.extend(
-    {vol.Optional(CONF_DEVICE_BAUDRATE, default=38400): int}
-)
-
 CONFIG_SCHEMA = CONFIG_SCHEMA.extend(
     {
-        vol.Required(CONF_DEVICE): SCHEMA_DEVICE,
-        vol.Optional(CONF_WATCHDOG_TTL, default=CONF_WATCHDOG_TTL_DEFAULT): vol.All(
-            int, vol.Range(min=180)
-        ),
         vol.Optional(
             CONF_MAX_CONCURRENT_REQUESTS, default=CONF_MAX_CONCURRENT_REQUESTS_DEFAULT
         ): CONFIG_SCHEMA.schema[CONF_MAX_CONCURRENT_REQUESTS],

--- a/zigpy_deconz/uart.py
+++ b/zigpy_deconz/uart.py
@@ -5,9 +5,8 @@ import binascii
 import logging
 from typing import Callable, Dict
 
+import zigpy.config
 import zigpy.serial
-
-from zigpy_deconz.config import CONF_DEVICE_BAUDRATE, CONF_DEVICE_PATH
 
 LOGGER = logging.getLogger(__name__)
 
@@ -127,18 +126,18 @@ async def connect(config: Dict[str, any], api: Callable) -> Gateway:
     connected_future = loop.create_future()
     protocol = Gateway(api, connected_future)
 
-    LOGGER.debug("Connecting to %s", config[CONF_DEVICE_PATH])
+    LOGGER.debug("Connecting to %s", config[zigpy.config.CONF_DEVICE_PATH])
 
     _, protocol = await zigpy.serial.create_serial_connection(
         loop=loop,
         protocol_factory=lambda: protocol,
-        url=config[CONF_DEVICE_PATH],
-        baudrate=config[CONF_DEVICE_BAUDRATE],
+        url=config[zigpy.config.CONF_DEVICE_PATH],
+        baudrate=config[zigpy.config.CONF_DEVICE_BAUDRATE],
         xonxoff=False,
     )
 
     await connected_future
 
-    LOGGER.debug("Connected to %s", config[CONF_DEVICE_PATH])
+    LOGGER.debug("Connected to %s", config[zigpy.config.CONF_DEVICE_PATH])
 
     return protocol

--- a/zigpy_deconz/zigbee/application.py
+++ b/zigpy_deconz/zigbee/application.py
@@ -415,9 +415,10 @@ class ControllerApplication(zigpy.application.ControllerApplication):
                 )
                 break
             except (asyncio.TimeoutError, zigpy.exceptions.DeliveryError):
+                if i == CONBEE_III_ENERGY_SCAN_ATTEMPTS - 1:
+                    raise
+
                 continue
-        else:
-            raise
 
         _, scanned_channels, _, _, energy_values = rsp
         return dict(zip(scanned_channels, energy_values))

--- a/zigpy_deconz/zigbee/application.py
+++ b/zigpy_deconz/zigbee/application.py
@@ -138,7 +138,10 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         )
 
         self.devices[self.state.node_info.ieee] = coordinator
-        if self._api.protocol_version >= PROTO_VER_NEIGBOURS:
+        if self._api.protocol_version >= PROTO_VER_NEIGBOURS and (
+            self._api.firmware_version.platform == FirmwarePlatform.Conbee_III
+            and self._api.firmware_version >= 0x264D0900
+        ):
             await self.restore_neighbours()
 
         self._delayed_neighbor_scan_task = asyncio.create_task(

--- a/zigpy_deconz/zigbee/application.py
+++ b/zigpy_deconz/zigbee/application.py
@@ -88,6 +88,41 @@ class ControllerApplication(zigpy.application.ControllerApplication):
 
             await asyncio.sleep(self._config[CONF_WATCHDOG_TTL] * 0.75)
 
+    @classmethod
+    async def probe(cls, device_config: dict[str, Any]) -> bool | dict[str, Any]:
+        """Probes the device specified by `device_config` and returns valid settings.
+
+        If the device is not supported, `False`.
+        """
+
+        device_config = zigpy.config.SCHEMA_DEVICE(device_config)
+        probe_configs = [device_config]
+
+        # Probe the Conbee III with 115200 if we aren't already doing so
+        if device_config[zigpy.config.CONF_DEVICE_BAUDRATE] != 115200:
+            probe_configs.append(
+                {**device_config, zigpy.config.CONF_DEVICE_BAUDRATE: 115200}
+            )
+
+        for device_config in probe_configs:
+            config = cls.SCHEMA(
+                {zigpy.config.CONF_DEVICE: cls.SCHEMA_DEVICE(device_config)}
+            )
+            app = cls(config)
+
+            try:
+                await app.connect()
+            except Exception:
+                LOGGER.debug(
+                    "Failed to probe with config %s", device_config, exc_info=True
+                )
+            else:
+                return device_config
+            finally:
+                await app.disconnect()
+
+        return False
+
     async def connect(self):
         api = Deconz(self, self._config[zigpy.config.CONF_DEVICE])
 

--- a/zigpy_deconz/zigbee/application.py
+++ b/zigpy_deconz/zigbee/application.py
@@ -140,9 +140,9 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         )
 
         self.devices[self.state.node_info.ieee] = coordinator
-        if self._api.protocol_version >= PROTO_VER_NEIGBOURS and (
+        if self._api.protocol_version >= PROTO_VER_NEIGBOURS and not (
             self._api.firmware_version.platform == FirmwarePlatform.Conbee_III
-            and self._api.firmware_version >= 0x264D0900
+            and self._api.firmware_version < 0x264D0900
         ):
             await self.restore_neighbours()
 

--- a/zigpy_deconz/zigbee/application.py
+++ b/zigpy_deconz/zigbee/application.py
@@ -40,7 +40,12 @@ from zigpy_deconz.api import (
     Status,
     TXStatus,
 )
-from zigpy_deconz.config import CONF_WATCHDOG_TTL, CONFIG_SCHEMA, SCHEMA_DEVICE
+from zigpy_deconz.config import (
+    CONF_DEVICE_BAUDRATE,
+    CONF_WATCHDOG_TTL,
+    CONFIG_SCHEMA,
+    SCHEMA_DEVICE,
+)
 import zigpy_deconz.exception
 
 LOGGER = logging.getLogger(__name__)
@@ -95,14 +100,12 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         If the device is not supported, `False`.
         """
 
-        device_config = zigpy.config.SCHEMA_DEVICE(device_config)
+        device_config = cls.SCHEMA_DEVICE(device_config)
         probe_configs = [device_config]
 
         # Probe the Conbee III with 115200 if we aren't already doing so
-        if device_config[zigpy.config.CONF_DEVICE_BAUDRATE] != 115200:
-            probe_configs.append(
-                {**device_config, zigpy.config.CONF_DEVICE_BAUDRATE: 115200}
-            )
+        if device_config[CONF_DEVICE_BAUDRATE] != 115200:
+            probe_configs.append({**device_config, CONF_DEVICE_BAUDRATE: 115200})
 
         for device_config in probe_configs:
             config = cls.SCHEMA(

--- a/zigpy_deconz/zigbee/application.py
+++ b/zigpy_deconz/zigbee/application.py
@@ -278,14 +278,15 @@ class ControllerApplication(zigpy.application.ControllerApplication):
             ),
         )
 
-        if network_info.security_level == 0x00:
-            await self._api.write_parameter(
-                NetworkParameter.security_mode, SecurityMode.NO_SECURITY
-            )
-        else:
-            await self._api.write_parameter(
-                NetworkParameter.security_mode, SecurityMode.ONLY_TCLK
-            )
+        if self._api.firmware_version.platform != FirmwarePlatform.Conbee_III:
+            if network_info.security_level == 0x00:
+                await self._api.write_parameter(
+                    NetworkParameter.security_mode, SecurityMode.NO_SECURITY
+                )
+            else:
+                await self._api.write_parameter(
+                    NetworkParameter.security_mode, SecurityMode.ONLY_TCLK
+                )
 
         # Note: Changed network configuration parameters become only affective after
         # sending a Leave Network Request followed by a Create or Join Network Request

--- a/zigpy_deconz/zigbee/application.py
+++ b/zigpy_deconz/zigbee/application.py
@@ -115,6 +115,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
             NetworkParameter.link_key,
             LinkKey(ieee=node, key=link_key),
         )
+        await self.permit(time_s)
 
     async def start_network(self):
         await self.register_endpoints()

--- a/zigpy_deconz/zigbee/application.py
+++ b/zigpy_deconz/zigbee/application.py
@@ -300,9 +300,6 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         await self._change_network_state(NetworkState.CONNECTED)
 
     async def load_network_info(self, *, load_devices=False):
-        if self._api.firmware_version.platform == FirmwarePlatform.Conbee_III:
-            await self._change_network_state(NetworkState.CONNECTED)
-
         network_info = self.state.network_info
         node_info = self.state.node_info
 

--- a/zigpy_deconz/zigbee/application.py
+++ b/zigpy_deconz/zigbee/application.py
@@ -117,8 +117,11 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         if self._api is not None:
             self._api.close()
 
-    async def permit_with_key(self, node: t.EUI64, code: bytes, time_s=60):
-        raise NotImplementedError()
+    async def permit_with_link_key(self, node: t.EUI64, link_key: t.KeyData, time_s=60):
+        await self._api.write_parameter(
+            NetworkParameter.link_key,
+            LinkKey(ieee=node, key=link_key),
+        )
 
     async def start_network(self):
         await self.register_endpoints()


### PR DESCRIPTION
Depends on https://github.com/zigpy/zigpy/pull/1281 to filter out extraneous ZDO endpoint in 0x26450900.

I'm targeting all available firmware versions for this device for this PR. Endpoint `0` being present in the simple descriptor response for the first firmware version will require a bugfix in zigpy.

To test:

```bash
pip uninstall zigpy zigpy-deconz
pip install 'git+https://github.com/puddly/zigpy-deconz@puddly/conbee-iii'
pip install 'git+https://github.com/puddly/zigpy@puddly/ignore-ep-0-descriptor'
```