### PR TITLE
Proper GPDF handling, forward to ZGP controller in application

### DIFF
--- a/zigpy_deconz/api.py
+++ b/zigpy_deconz/api.py
@@ -14,16 +14,17 @@ else:
     from asyncio import timeout as asyncio_timeout  # pragma: no cover
 
 from zigpy.config import CONF_DEVICE_PATH
-import zigpy.greenpower
 from zigpy.types import (
     APSStatus,
     Bool,
     Channels,
-    GPDataFrame,
     KeyData,
     SerializableBytes,
     Struct,
     ZigbeePacket,
+)
+from zigpy.zgp.types import (
+    GPDataFrame,
 )
 from zigpy.zdo.types import SimpleDescriptor
 


### PR DESCRIPTION
Early pull to utilize the code found in https://github.com/zigpy/zigpy/pull/1282 to properly deserialize and forward GPDFs. Stops some log spam when we receive direct green power data frames more than anything.