### PR TITLE
Revert watchdog back to once every 7.5 minutes

### DIFF
--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -337,7 +337,7 @@ async def test_reset_watchdog(app):
     app._api.write_parameter = AsyncMock()
 
     await app._watchdog_feed()
-    assert len(app._api.get_device_state.mock_calls) == 1
+    assert len(app._api.get_device_state.mock_calls) == 0
     assert len(app._api.write_parameter.mock_calls) == 1
 
     app._api.protocol_version = application.PROTO_VER_WATCHDOG - 1

--- a/zigpy_deconz/zigbee/application.py
+++ b/zigpy_deconz/zigbee/application.py
@@ -64,6 +64,8 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         {zigpy.config.CONF_DEVICE_BAUDRATE: 115200},
     ]
 
+    _watchdog_period = 600 * 0.75
+
     def __init__(self, config: dict[str, Any]):
         """Initialize instance."""
 
@@ -78,15 +80,15 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         self._written_endpoints = set()
 
     async def _watchdog_feed(self):
-        await self._api.get_device_state()
-
         if self._api.protocol_version >= PROTO_VER_WATCHDOG and not (
             self._api.firmware_version.platform == FirmwarePlatform.Conbee_III
             and self._api.firmware_version <= 0x26450900
         ):
             await self._api.write_parameter(
-                NetworkParameter.watchdog_ttl, int(2 * self._watchdog_period)
+                NetworkParameter.watchdog_ttl, int(self._watchdog_period / 0.75)
             )
+        else:
+            await self._api.get_device_state()
 
     async def connect(self):
         api = Deconz(self, self._config[zigpy.config.CONF_DEVICE])


### PR DESCRIPTION
#232 changed the watchdog period to 30s. It seems like the Conbee at times can delay serial command processing in some setups and the watchdog can trigger, breaking startup.

This change reverts it back to the original value.

---

See: https://github.com/home-assistant/core/issues/105506