### PR TITLE
Detect when the firmware responds with the wrong response

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,3 +61,11 @@ ignore = [
     "D103", "D102", "D101",  # TODO: remove these once docstrings are added
 ]
 per-file-ignores = ["tests/*:F811,F401,F403"]
+
+[tool.coverage.report]
+exclude_also = [
+    "raise AssertionError",
+    "raise NotImplementedError",
+    "if (typing\\.)?TYPE_CHECKING:",
+    "@(abc\\.)?abstractmethod",
+]

--- a/zigpy_deconz/exception.py
+++ b/zigpy_deconz/exception.py
@@ -1,6 +1,13 @@
 """Zigpy-deconz exceptions."""
 
+from __future__ import annotations
+
+import typing
+
 from zigpy.exceptions import APIException
+
+if typing.TYPE_CHECKING:
+    from zigpy_deconz.api import CommandId
 
 
 class CommandError(APIException):
@@ -12,3 +19,13 @@ class CommandError(APIException):
     @property
     def status(self):
         return self._status
+
+
+class MismatchedResponseError(APIException):
+    def __init__(
+        self, command_id: CommandId, params: dict[str, typing.Any], *args, **kwargs
+    ) -> None:
+        """Initialize instance."""
+        super().__init__(*args, **kwargs)
+        self.command_id = command_id
+        self.params = params

--- a/zigpy_deconz/zigbee/application.py
+++ b/zigpy_deconz/zigbee/application.py
@@ -80,21 +80,15 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         self._written_endpoints = set()
 
     async def _watchdog_feed(self):
-        while True:
-            try:
-                if self._api.protocol_version >= PROTO_VER_WATCHDOG and not (
-                    self._api.firmware_version.platform == FirmwarePlatform.Conbee_III
-                    and self._api.firmware_version <= 0x26450900
-                ):
-                    await self._api.write_parameter(
-                        NetworkParameter.watchdog_ttl, int(self._watchdog_period / 0.75)
-                    )
-                else:
-                    await self._api.get_device_state()
-
-                break
-            except zigpy_deconz.exception.MismatchedResponseError as exc:
-                LOGGER.debug("Firmware responded unexpectedly to watchdog: %s", exc)
+        if self._api.protocol_version >= PROTO_VER_WATCHDOG and not (
+            self._api.firmware_version.platform == FirmwarePlatform.Conbee_III
+            and self._api.firmware_version <= 0x26450900
+        ):
+            await self._api.write_parameter(
+                NetworkParameter.watchdog_ttl, int(self._watchdog_period / 0.75)
+            )
+        else:
+            await self._api.get_device_state()
 
     async def connect(self):
         api = Deconz(self, self._config[zigpy.config.CONF_DEVICE])


### PR DESCRIPTION
Detected with a Raspbee II (0x26780700) (thanks @Citizen-2CB8A24A):

```Python
# Watchdog TTL write (seq=101)
2023-12-16 00:31:24.247 DEBUG (MainThread) [zigpy_deconz.api] Sending CommandId.write_parameter{'parameter_id': <NetworkParameter.watchdog_ttl: 38>, 'parameter': b'<\x00\x00\x00'} (seq=101)
2023-12-16 00:31:24.248 DEBUG (MainThread) [zigpy_deconz.uart] Send: 0b65000c000500263c000000

# Response received, but the wrong one (device_state_changed??) (seq=101)
2023-12-16 00:31:25.470 DEBUG (MainThread) [zigpy_deconz.uart] Frame received: 0x0e65000700aa00
2023-12-16 00:31:25.471 DEBUG (MainThread) [zigpy_deconz.api] Received command CommandId.device_state_changed{'status': <Status.SUCCESS: 0>, 'frame_length': 7, 'device_state': DeviceState(network_state=<NetworkState2.CONNECTED: 2>, device_state=<DeviceStateFlags.APSDE_DATA_INDICATION|APSDE_DATA_REQUEST_FREE_SLOTS_AVAILABLE|32: 42>), 'reserved': 0} (seq 101)

# Another device_state_changed received (seq=102) right after
2023-12-16 00:31:25.648 DEBUG (MainThread) [zigpy_deconz.uart] Frame received: 0x0e66000700aa00
2023-12-16 00:31:25.650 DEBUG (MainThread) [zigpy_deconz.api] Received command CommandId.device_state_changed{'status': <Status.SUCCESS: 0>, 'frame_length': 7, 'device_state': DeviceState(network_state=<NetworkState2.CONNECTED: 2>, device_state=<DeviceStateFlags.APSDE_DATA_INDICATION|APSDE_DATA_REQUEST_FREE_SLOTS_AVAILABLE|32: 42>), 'reserved': 0} (seq 102)
```

From the log, you can see that the `write_parameter` request doesn't receive the correct response. It's almost as if the enqueued `device_state_changed` notification overwrites the expected `write_parameter` response.

A separate exception type is used to detect this rare problem and the watchdog TTL will be re-written until it succeeds.