### PR TITLE
Handle CB3 not sending the correct `add_neighbor` response

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -961,6 +961,65 @@ async def test_add_neighbour(api, mock_command_rsp):
     ]
 
 
+async def test_add_neighbour_conbee3_success(api):
+    api._command = AsyncMock(wraps=api._command)
+    api._uart = AsyncMock()
+
+    # Simulate a good but invalid response from the Conbee III
+    asyncio.get_running_loop().call_later(
+        0.001,
+        lambda: api.data_received(
+            b"\x1d" + bytes([api._seq - 1]) + b"\x00\x06\x00\x01"
+        ),
+    )
+
+    await api.add_neighbour(
+        nwk=0x1234,
+        ieee=t.EUI64.convert("aa:bb:cc:dd:11:22:33:44"),
+        mac_capability_flags=0x12,
+    )
+
+    assert api._command.mock_calls == [
+        call(
+            deconz_api.CommandId.update_neighbor,
+            action=deconz_api.UpdateNeighborAction.ADD,
+            nwk=0x1234,
+            ieee=t.EUI64.convert("aa:bb:cc:dd:11:22:33:44"),
+            mac_capability_flags=0x12,
+        )
+    ]
+
+
+async def test_add_neighbour_conbee3_failure(api):
+    api._command = AsyncMock(wraps=api._command)
+    api._uart = AsyncMock()
+
+    # Simulate a bad response from the Conbee III
+    asyncio.get_running_loop().call_later(
+        0.001,
+        lambda: api.data_received(
+            b"\x1d" + bytes([api._seq - 1]) + b"\x01\x06\x00\x01"
+        ),
+    )
+
+    with pytest.raises(deconz_api.CommandError):
+        await api.add_neighbour(
+            nwk=0x1234,
+            ieee=t.EUI64.convert("aa:bb:cc:dd:11:22:33:44"),
+            mac_capability_flags=0x12,
+        )
+
+    assert api._command.mock_calls == [
+        call(
+            deconz_api.CommandId.update_neighbor,
+            action=deconz_api.UpdateNeighborAction.ADD,
+            nwk=0x1234,
+            ieee=t.EUI64.convert("aa:bb:cc:dd:11:22:33:44"),
+            mac_capability_flags=0x12,
+        )
+    ]
+
+
 async def test_cb3_device_state_callback_bug(api, mock_command_rsp):
     mock_command_rsp(
         command_id=deconz_api.CommandId.version,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -755,7 +755,7 @@ async def test_bad_command_parsing(api, caplog):
 
     assert 0xFF not in deconz_api.COMMAND_SCHEMAS
 
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(logging.DEBUG):
         api.data_received(
             bytes.fromhex(
                 "172c002f0028002e02000000020000000000"

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -216,7 +216,7 @@ async def test_disconnect_no_api(app):
 
 async def test_disconnect_close_error(app):
     app._api.write_parameter = MagicMock(
-        side_effect=zigpy_deconz.exception.CommandError(1, "Error")
+        side_effect=zigpy_deconz.exception.CommandError("Error", status=1, command=None)
     )
     await app.disconnect()
 
@@ -399,13 +399,17 @@ async def test_restore_neighbours(app, caplog):
 
         if max_neighbors < 0:
             raise zigpy_deconz.exception.CommandError(
-                deconz_api.Status.FAILURE, "Failure"
+                "Failure",
+                status=deconz_api.Status.FAILURE,
+                command=None,
             )
 
     p = patch.object(app, "_api", spec_set=zigpy_deconz.api.Deconz(None, None))
 
     with p as api_mock:
-        err = zigpy_deconz.exception.CommandError(deconz_api.Status.FAILURE, "Failure")
+        err = zigpy_deconz.exception.CommandError(
+            "Failure", status=deconz_api.Status.FAILURE, command=None
+        )
         api_mock.add_neighbour = AsyncMock(side_effect=[None, err, err, err])
 
         with caplog.at_level(logging.DEBUG):
@@ -483,7 +487,9 @@ async def test_add_endpoint(app, descriptor, slots, target_slot):
 
         if index not in slots:
             raise zigpy_deconz.exception.CommandError(
-                deconz_api.Status.UNSUPPORTED, "Unsupported"
+                "Unsupported",
+                status=deconz_api.Status.UNSUPPORTED,
+                command=None,
             )
         else:
             return deconz_api.IndexedEndpoint(index=index, descriptor=slots[index])
@@ -504,7 +510,9 @@ async def test_add_endpoint_no_free_space(app):
         assert index in (0x00, 0x01)
 
         raise zigpy_deconz.exception.CommandError(
-            deconz_api.Status.UNSUPPORTED, "Unsupported"
+            "Unsupported",
+            status=deconz_api.Status.UNSUPPORTED,
+            command=None,
         )
 
     app._api.read_parameter = AsyncMock(side_effect=read_param)
@@ -524,7 +532,9 @@ async def test_add_endpoint_no_unnecessary_writes(app):
 
         if index > 0x01:
             raise zigpy_deconz.exception.CommandError(
-                deconz_api.Status.UNSUPPORTED, "Unsupported"
+                "Unsupported",
+                status=deconz_api.Status.UNSUPPORTED,
+                command=None,
             )
 
         return deconz_api.IndexedEndpoint(

--- a/tests/test_exception.py
+++ b/tests/test_exception.py
@@ -7,6 +7,9 @@ import zigpy_deconz.exception
 
 def test_command_error():
     ex = zigpy_deconz.exception.CommandError(
-        mock.sentinel.status, mock.sentinel.message
+        mock.sentinel.message,
+        status=mock.sentinel.status,
+        command=mock.sentinel.command,
     )
     assert ex.status is mock.sentinel.status
+    assert ex.command is mock.sentinel.command

--- a/tests/test_network_state.py
+++ b/tests/test_network_state.py
@@ -212,7 +212,9 @@ async def test_write_network_info(
             None,
             {
                 ("nwk_frame_counter",): zigpy_deconz.exception.CommandError(
-                    zigpy_deconz.api.Status.UNSUPPORTED
+                    "Some error",
+                    status=zigpy_deconz.api.Status.UNSUPPORTED,
+                    command=None,
                 )
             },
             {"network_key.tx_counter": 0},

--- a/tests/test_network_state.py
+++ b/tests/test_network_state.py
@@ -123,7 +123,9 @@ async def test_write_network_info(
             and param == zigpy_deconz.api.NetworkParameter.nwk_frame_counter
         ):
             raise zigpy_deconz.exception.CommandError(
-                status=zigpy_deconz.api.Status.UNSUPPORTED
+                "Command is unsupported",
+                status=zigpy_deconz.api.Status.UNSUPPORTED,
+                command=None,
             )
 
         params[param.name] = args

--- a/tests/test_send_receive.py
+++ b/tests/test_send_receive.py
@@ -8,7 +8,7 @@ import pytest
 import zigpy.exceptions
 import zigpy.types as zigpy_t
 
-from zigpy_deconz.api import TXStatus
+from zigpy_deconz.api import Status, TXStatus
 import zigpy_deconz.exception
 import zigpy_deconz.types as t
 
@@ -23,7 +23,9 @@ def patch_data_request(app, *, fail_enqueue=False, fail_deliver=False):  # noqa:
             await asyncio.sleep(0)
 
             if fail_enqueue:
-                raise zigpy_deconz.exception.CommandError("Error")
+                raise zigpy_deconz.exception.CommandError(
+                    "Error", status=Status.FAILURE, command=None
+                )
 
             if fail_deliver:
                 app.handle_tx_confirm(

--- a/zigpy_deconz/exception.py
+++ b/zigpy_deconz/exception.py
@@ -7,18 +7,19 @@ import typing
 from zigpy.exceptions import APIException
 
 if typing.TYPE_CHECKING:
-    from zigpy_deconz.api import CommandId
+    from zigpy_deconz.api import Command, CommandId, Status
 
 
 class CommandError(APIException):
-    def __init__(self, status=1, *args, **kwargs):
+    def __init__(self, *args, status: Status, command: Command, **kwargs):
         """Initialize instance."""
-        self._status = status
         super().__init__(*args, **kwargs)
+        self.command = command
+        self.status = status
 
-    @property
-    def status(self):
-        return self._status
+
+class ParsingError(CommandError):
+    pass
 
 
 class MismatchedResponseError(APIException):


### PR DESCRIPTION
The Conbee III's firmware currently responds to `add_neighbor` commands with an invalid response.

https://github.com/home-assistant/core/issues/109287