### PR TITLE
Register the command response listener before writing to the UART

### DIFF
--- a/zigpy_deconz/api.py
+++ b/zigpy_deconz/api.py
@@ -572,16 +572,15 @@ class Deconz:
 
         async with self._command_lock(priority=self._get_command_priority(command)):
             seq = self._seq
-
-            LOGGER.debug("Sending %s%s (seq=%s)", cmd, kwargs, seq)
-            self._uart.send(command.replace(seq=seq).serialize())
-
             self._seq = (self._seq % 255) + 1
 
             fut = asyncio.Future()
             self._awaiting[seq][cmd].append(fut)
 
             try:
+                LOGGER.debug("Sending %s%s (seq=%s)", cmd, kwargs, seq)
+                self._uart.send(command.replace(seq=seq).serialize())
+
                 async with asyncio_timeout(COMMAND_TIMEOUT):
                     return await fut
             except asyncio.TimeoutError:


### PR DESCRIPTION
See https://github.com/home-assistant/core/issues/109931.

More precisely:


```python
2024-02-08 00:17:53.874 DEBUG (MainThread) [zigpy.application] Feeding watchdog
2024-02-08 00:17:53.874 DEBUG (MainThread) [zigpy_deconz.api] Sending CommandId.write_parameter{'parameter_id': <NetworkParameter.watchdog_ttl: 38>, 'parameter': b'<\x00\x00\x00'} (seq=98)
2024-02-08 00:17:53.874 DEBUG (MainThread) [zigpy_deconz.uart] Send: 0b62000c000500263c000000
2024-02-08 00:17:53.876 DEBUG (MainThread) [zigpy_deconz.uart] Frame received: 0x0b62000800010026
2024-02-08 00:17:53.876 DEBUG (MainThread) [zigpy_deconz.api] Received command CommandId.write_parameter{'status': <Status.SUCCESS: 0>, 'frame_length': 8, 'payload_length': 1, 'parameter_id': <NetworkParameter.watchdog_ttl: 38>} (seq 98)
2024-02-08 00:17:55.675 DEBUG (MainThread) [zigpy_deconz.api] No response to 'CommandId.write_parameter' command with seq 98
```

It appears that we can write to the serial port and receive a response before the listener is registered a few lines down.

This is a bug probably exposed by us switching to pyserial-asyncio-fast.