### PR TITLE
Fix unit tests relying on double config conversion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ license = {text = "GPL-3.0"}
 requires-python = ">=3.8"
 dependencies = [
     "voluptuous",
-    "zigpy>=0.60.2",
+    "zigpy>=0.65.3",
     'async-timeout; python_version<"3.11"',
 ]
 

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -55,12 +55,10 @@ def api():
 
 @pytest.fixture
 def app(device_path, api):
-    config = application.ControllerApplication.SCHEMA(
-        {
-            **ZIGPY_NWK_CONFIG,
-            zigpy.config.CONF_DEVICE: {zigpy.config.CONF_DEVICE_PATH: device_path},
-        }
-    )
+    config = {
+        **ZIGPY_NWK_CONFIG,
+        zigpy.config.CONF_DEVICE: {zigpy.config.CONF_DEVICE_PATH: device_path},
+    }
 
     app = application.ControllerApplication(config)
 
@@ -426,12 +424,10 @@ async def test_delayed_scan():
     """Delayed scan."""
 
     coord = MagicMock()
-    config = application.ControllerApplication.SCHEMA(
-        {
-            zigpy.config.CONF_DEVICE: {zigpy.config.CONF_DEVICE_PATH: "usb0"},
-            zigpy.config.CONF_DATABASE: "tmp",
-        }
-    )
+    config = {
+        zigpy.config.CONF_DEVICE: {zigpy.config.CONF_DEVICE_PATH: "usb0"},
+        zigpy.config.CONF_DATABASE: "tmp",
+    }
 
     app = application.ControllerApplication(config)
     with patch.object(app, "get_device", return_value=coord):


### PR DESCRIPTION
A few unit tests perform double conversion as well. Depends on https://github.com/zigpy/zigpy/pull/1433