### PR TITLE
Fail adapter migration if the frame counter cannot be written

### DIFF
--- a/tests/test_network_state.py
+++ b/tests/test_network_state.py
@@ -3,7 +3,7 @@
 import importlib.metadata
 
 import pytest
-from zigpy.exceptions import NetworkNotFormed
+from zigpy.exceptions import ControllerException, NetworkNotFormed
 import zigpy.state as app_state
 import zigpy.types as t
 import zigpy.zdo.types as zdo_t
@@ -140,6 +140,21 @@ async def test_write_network_info(
     )
 
     node_info = node_info.replace(logical_type=logical_type)
+
+    if not fw_supports_fc:
+        with pytest.raises(
+            ControllerException,
+            match=(
+                "Please upgrade your adapter firmware. Firmware version 0x26580700 does"
+                " not support writing the network key frame counter, which is required"
+                " for migration to succeed."
+            ),
+        ):
+            await app.write_network_info(
+                network_info=network_info,
+                node_info=node_info,
+            )
+        return
 
     await app.write_network_info(
         network_info=network_info,

--- a/zigpy_deconz/zigbee/application.py
+++ b/zigpy_deconz/zigbee/application.py
@@ -189,9 +189,11 @@ class ControllerApplication(zigpy.application.ControllerApplication):
             )
         except zigpy_deconz.exception.CommandError as ex:
             assert ex.status == Status.UNSUPPORTED
-            LOGGER.warning(
-                "Writing the network frame counter is not supported with this firmware,"
-                " please update your Conbee"
+            fw_version = f"{int(self._api.firmware_version):#010x}"
+            raise zigpy.exceptions.ControllerException(
+                f"Please upgrade your adapter firmware. Firmware version {fw_version}"
+                f" does not support writing the network key frame counter, which is"
+                f" required for migration to succeed."
             )
 
         if node_info.logical_type == zdo_t.LogicalType.Coordinator:


### PR DESCRIPTION
Similar to https://github.com/zigpy/bellows/pull/672, this is not a good default.