### PR TITLE
Allow backup to complete on old FW versions

### DIFF
--- a/tests/test_network_state.py
+++ b/tests/test_network_state.py
@@ -234,7 +234,7 @@ async def test_write_network_info(
                     command=None,
                 )
             },
-            {"network_key.tx_counter": 0},
+            {"network_key.tx_counter": 1073741824},
             {},
         ),
         (

--- a/zigpy_deconz/zigbee/application.py
+++ b/zigpy_deconz/zigbee/application.py
@@ -365,6 +365,11 @@ class ControllerApplication(zigpy.application.ControllerApplication):
             )
         except zigpy_deconz.exception.CommandError as ex:
             assert ex.status == Status.UNSUPPORTED
+            LOGGER.debug(
+                "Conbee firmware is too old and does not support reading the frame"
+                " counter, picking a large value instead"
+            )
+            network_info.network_key.tx_counter = 2**30
 
         network_info.tc_link_key = zigpy.state.Key()
         network_info.tc_link_key.partner_ieee = await self._api.read_parameter(


### PR DESCRIPTION
Older firmwares do not expose the network key frame counter and thus are unusable. Many people are unfortunately still using old firmwares so instead of breaking their installations, we should allow backup/restore to succeed by picking a "safe" value for the network key frame counter.

I've chosen 1/4 of the maximum value, so a little over 1 billion. It's unlikely many people heavily using Zigbee would approach it.