### PR TITLE
Only await TX confirm if APS ACKs are requested

### DIFF
--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -323,10 +323,8 @@ def test_tx_confirm_dup(app, caplog):
     assert "probably duplicate response" in caplog.text
 
 
-def test_tx_confirm_unexpcted(app, caplog):
+def test_tx_confirm_unexpcted(app):
     app.handle_tx_confirm(123, 0x00)
-    assert any(r.levelname == "WARNING" for r in caplog.records)
-    assert "Unexpected transmit confirm for request id" in caplog.text
 
 
 async def test_reset_watchdog(app):

--- a/tests/test_send_receive.py
+++ b/tests/test_send_receive.py
@@ -206,3 +206,10 @@ async def test_send_packet_deliver_failure(app, tx_packet):  # noqa: F811
             await app.send_packet(tx_packet)
 
     assert "Failed to deliver" in str(e)
+
+
+async def test_send_packet_no_ack_ignores_deliver_failure(app, tx_packet):  # noqa: F811
+    tx_packet.tx_options &= ~zigpy_t.TransmitOptions.ACK
+    with patch_data_request(app, fail_deliver=True):
+        await app.send_packet(tx_packet)
+    assert len(app._pending_requests) == 0

--- a/zigpy_deconz/zigbee/application.py
+++ b/zigpy_deconz/zigbee/application.py
@@ -583,14 +583,14 @@ class ControllerApplication(zigpy.application.ControllerApplication):
                     raise zigpy.exceptions.DeliveryError(
                         f"Failed to enqueue packet: {ex!r}", ex.status
                     )
+                if tx_options & t.DeconzTransmitOptions.USE_APS_ACKS:
+                    async with asyncio_timeout(SEND_CONFIRM_TIMEOUT):
+                        status = await future
 
-                async with asyncio_timeout(SEND_CONFIRM_TIMEOUT):
-                    status = await future
-
-                if status != TXStatus.SUCCESS:
-                    raise zigpy.exceptions.DeliveryError(
-                        f"Failed to deliver packet: {status!r}", status
-                    )
+                    if status != TXStatus.SUCCESS:
+                        raise zigpy.exceptions.DeliveryError(
+                            f"Failed to deliver packet: {status!r}", status
+                        )
             finally:
                 del self._pending_requests[req_id]
 
@@ -602,8 +602,8 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         try:
             future = self._pending_requests[req_id]
         except KeyError:
-            LOGGER.warning(
-                "Unexpected transmit confirm for request id %s, Status: %s",
+            LOGGER.debug(
+                "Transmit confirm for request id %s, Status: %s",
                 req_id,
                 status,
             )


### PR DESCRIPTION
I have had issues in my system where `send_packet` waits for the full `SEND_CONFIRM_TIMEOUT` regardless if `zigpy.types.TransmitOptions.ACK` is present in the packet. This causes delays when many devices are offline.

With this change, TX confirm is only awaited when APS ACKs are requested.

_Note: `handle_tx_confirm` **will still fire** without a future in the `_pending_requests`, this is inherent in how the Network operates, so the warning that was raised has been changed to a debug message to reflect this._