### PR TITLE
Support `APS_Encryption` transmit option

### DIFF
--- a/tests/test_send_receive.py
+++ b/tests/test_send_receive.py
@@ -96,6 +96,21 @@ async def test_send_packet_nwk_no_ack(app, tx_packet):  # noqa: F811
     assert req["radius"] == 0
 
 
+async def test_send_packet_nwk_aps_encryption(app, tx_packet):  # noqa: F811
+    tx_packet.tx_options |= zigpy_t.TransmitOptions.APS_Encryption
+
+    with patch_data_request(app) as mock_req:
+        await app.send_packet(tx_packet)
+
+    assert len(mock_req.mock_calls) == 1
+    req = mock_req.mock_calls[0].kwargs
+
+    # The network key security option is replaced by APS encryption
+    assert req["tx_options"] == (
+        t.DeconzTransmitOptions.SECURITY_ENABLED | t.DeconzTransmitOptions.USE_APS_ACKS
+    )
+
+
 async def test_send_packet_source_route(app, tx_packet):  # noqa: F811
     tx_packet.source_route = [0xAABB, 0xCCDD]
 

--- a/zigpy_deconz/zigbee/application.py
+++ b/zigpy_deconz/zigbee/application.py
@@ -545,7 +545,12 @@ class ControllerApplication(zigpy.application.ControllerApplication):
     async def send_packet(self, packet):
         LOGGER.debug("Sending packet: %r", packet)
 
-        tx_options = t.DeconzTransmitOptions.USE_NWK_KEY_SECURITY
+        if zigpy.types.TransmitOptions.APS_Encryption in packet.tx_options:
+            # APS encryption is performed with the link key, not the network key, so
+            # the "use NWK key" option must not be set
+            tx_options = t.DeconzTransmitOptions.SECURITY_ENABLED
+        else:
+            tx_options = t.DeconzTransmitOptions.USE_NWK_KEY_SECURITY
 
         if (
             zigpy.types.TransmitOptions.ACK in packet.tx_options


### PR DESCRIPTION
zigpy sets `TransmitOptions.APS_Encryption` for unicasts that require APS layer encryption (currently the Zigbee Direct Configuration cluster, which rejects unencrypted frames with `NOT_AUTHORIZED`). Map it onto deCONZ's `SECURITY_ENABLED` TX option.

APS security uses the (trust center) link key, so `USE_NWK_KEY_SECURITY` must not be set at the same time.

Related zigpy PR that requires this (but zigpy-deconz doesn't require a new zigpy version):
- https://github.com/zigpy/zigpy/pull/1867